### PR TITLE
Fix a warning during compilation and show classes after instanceof

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -967,6 +967,10 @@ current `tags-file-name'."
     '("\\<\\(new\\|extends\\|implements\\)\\s-+\\$?\\(\\(:?\\sw\\|\\\\\\)+\\)"
       (1 font-lock-keyword-face) (2 font-lock-type-face nil t))
 
+    ;; instanceof operator
+    '("\\<instanceof\\s-+\\([^$]\\(:?\\sw\\|\\\\\\)+\\)"
+      (1 font-lock-type-face nil t))
+
     ;; namespace imports
     '("\\<\\(use\\)\\s-+\\(\\(?:\\sw\\|\\\\\\)+\\)"
       (1 font-lock-keyword-face)


### PR DESCRIPTION
When I'd compile the php-mode.el I'd get the warning to use `with-current-buffer` instead of the `save-excursion` followed by `set-buffer` combination. I checked and `with-current-buffer` was already used somewhere else in php-mode.el, so I thought it couldn't do any harm.

Also, statements like `$a instanceof MyClass` didn't fontify the `MyClass` as a class.
