### PR TITLE
Fixed bug with displaying strings in bacquotes.

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -448,6 +448,7 @@ This is was done due to the problem reported here:
 
   (modify-syntax-entry ?# "< b" php-mode-syntax-table)
   (modify-syntax-entry ?_ "_" php-mode-syntax-table)
+  (modify-syntax-entry ?` "\"" php-mode-syntax-table)
 
   (setq font-lock-maximum-decoration t
         imenu-generic-expression php-imenu-generic-expression)


### PR DESCRIPTION
Problem with syntax highlighting was appeared on string like:

`cp upload/{$app}/files/* upload/{$app}/images/* upload/{$app}/thumbs/* upload/{$app}/temp/*`;
