### PR TITLE
Minor fixes

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1159,7 +1159,7 @@ searching the PHP website."
     '("\\(\\(\\sw\\|\\\\\\)+\\)::\\sw+\\s-*(?" . (1 font-lock-type-face))
 
     ;; class::constant
-    '("::\\(\\sw+\\>[^(]\\)" . (1 php-default-face))
+    '("::\\(\\(?:\\sw\\|\\s_\\)+\\>\\)[^(]" . (1 font-lock-constant-face))
 
     ;; using a trait in a class
     '("\\<use\\s-+\\(\\sw+\\)\\s-*;" . (1 font-lock-type-face))


### PR DESCRIPTION
I only really thought you might be interested in the last 2 commits, but I can't keep the first 2 from coming along.

I thought these 2 might be nice. The first one fixes a case where a class name (for type hinting) not on the same line as the function name doesn't get recognized as a class name and the second one fixes certain cases where class constants aren't recognized when certain characters follow them. Also the second one changes the class constant face from `php-default-face` to `font-lock-constant-face`, I thought that would make more sense.
