### PR TITLE
Search words on PHP online manual

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -170,7 +170,7 @@ can be used to match against definitions for that classlike."
     "^\\s-*function\\s-+\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*(" 1))
  "Imenu generic expression for PHP Mode. See `imenu-generic-expression'.")
 
-(defcustom php-manual-url "http://www.php.net/manual/en/"
+(defcustom php-manual-url "http://www.php.net/manual-lookup.php?pattern="
   "URL at which to find PHP manual.
 You can replace \"en\" with your ISO language code."
   :type 'string
@@ -681,11 +681,20 @@ searching the PHP website."
             (php-search-web-documentation))
       (php-search-web-documentation))))
 
+;; Open URL in other window
+(defun browse-url-other-window (url &optional newwin)
+  "Open url in other window"
+  (message "Openning PHP online manual...")
+  (let ((pop-up-windows t))
+    (if (one-window-p)(split-window-sensibly (frame-selected-window)))
+    (other-window 1)
+    (browse-url url newwin)))
+
 ;; Define function for browsing manual
 (defun php-browse-manual ()
   "Bring up manual for PHP."
   (interactive)
-  (browse-url php-manual-url))
+  (browse-url-other-window (concat php-manual-url (current-word))))
 
 ;; Define shortcut
 (define-key php-mode-map


### PR DESCRIPTION
Hi Eric,

Thanks for your php-mode.el, it helps me alot. :-)

Maybe searching the current term under cursor on http://www.php.net is better than just open the PHP online manual? I have just finished these modifications, and now pressing `C-c C-m` will open the required manual page in a new window.

I'm a rookie elisp programmer, do not laugh at me :P
