### PR TITLE
Add "die" to list of language constructs

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -729,8 +729,8 @@ searching the PHP website."
   (eval-when-compile
     (regexp-opt
      '(;; core constants
-       "__LINE__" "__FILE__"
-       "__FUNCTION__" "__CLASS__" "__METHOD__"
+       "__LINE__" "__FILE__" "__DIR__"
+       "__FUNCTION__" "__CLASS__" "__TRAIT__" "__METHOD__"
        "__NAMESPACE__"
        "__COMPILER_HALT_OFFSET__"
        "PHP_OS" "PHP_VERSION"


### PR DESCRIPTION
It is equivalent to exit, so it should be treated by Emacs the same way
