### PR TITLE
Some improvements to  Issue #33:  indentation styles for drupal and wordpress

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -250,11 +250,22 @@ This variable can take one of the following symbol values:
 `Drupal' - use coding styles preferred for working with Drupal projects.
 
 `WordPress' - use coding styles preferred for working with WordPress projects."
-  :type '(radio (const :tag "PEAR" pear)
-				(const :tag "Drupal" drupal)
-				(const :tag "WordPress" wordpress))
-  :group 'php)
+  :type '(choice (const :tag "PEAR" pear)
+				 (const :tag "Drupal" drupal)
+				 (const :tag "WordPress" wordpress))
+  :group 'php
+  :set 'php-mode-custom-coding-style-set
+  :initialize 'custom-initialize-default)
 
+(defun php-mode-custom-coding-style-set (sym value)
+  (set         sym value)
+  (set-default sym value)
+  (cond ((eq value 'pear)
+  		 (php-enable-pear-coding-style))
+		((eq value 'drupal)
+  		 (php-enable-drupal-coding-style))
+		((eq value 'wordpress)
+		 (php-enable-wordpress-coding-style))))
 
 (defun php-enable-pear-coding-style ()
   "Sets up php-mode to use the coding styles preferred for PEAR
@@ -576,17 +587,20 @@ This is was done due to the problem reported here:
   (add-hook 'php-mode-pear-hook 'php-enable-pear-coding-style
              nil t)
 
-  ;; Drupal coding standards
+  ;; ;; Drupal coding standards
   (add-hook 'php-mode-drupal-hook 'php-enable-drupal-coding-style
              nil t)
 
-  ;; WordPress coding standards
+  ;; ;; WordPress coding standards
   (add-hook 'php-mode-wordpress-hook 'php-enable-wordpress-coding-style
              nil t)
 
-  (cond ((eq php-mode-coding-style 'pear) (message "PEAR style"))
-		((eq php-mode-coding-style 'drupal) (message "Drupal style"))
-		((eq php-mode-coding-style 'wordpress) (message "Wordpress style")))
+  (cond ((eq php-mode-coding-style 'pear)
+  		 (run-hooks 'php-mode-pear-hook))
+  		((eq php-mode-coding-style 'drupal)
+  		 (run-hooks 'php-mode-drupal-hook))
+  		((eq php-mode-coding-style 'wordpress)
+  		 (run-hooks 'php-mode-wordpress-hook)))
 
   (if (or php-mode-force-pear
           (and (stringp buffer-file-name)


### PR DESCRIPTION
php-enable-*-coding-style set as interactive.

With this users could M-x php-enable-(pear/drupal/wordpress)-coding-style and change coding style on the fly for current buffer.

Added customization settings that allow to select default coding style and save to init.el

Added custom hooks for coding styles, which allow users to extend their drupal/pear/wordpress settings.

Please review my code. It should be ok. But I'm just a beginner with lisp, so I'm not 100% sure.
