### PR TITLE
Ert tests for files within the "tests" directory

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -66,6 +66,7 @@ the coding style to one of `pear', `drupal', or `wordpress'."
   "Single quote in text in HTML misinterpreted.
 The next character after \">We\" is a single quote. It should not
 have a string face."
+  :expected-result :failed
   (with-php-mode-test ("issue-9.php")
     (should-not (eq
                  (get-text-property (search-forward ">We") 'face)
@@ -73,6 +74,7 @@ have a string face."
 
 (ert-deftest php-mode-test-issue-14 ()
   "Array indentation."
+  :expected-result :failed
   (with-php-mode-test ("issue-14.php")
     (let ((expected (concat "$post = Post::model()->find(array(\n"
                             "    'select' => 'title',\n"
@@ -108,6 +110,7 @@ Gets the face of the text after the comma."
 
 (ert-deftest php-mode-test-issue-19 ()
   "Alignment of arrow operators."
+  :expected-result :failed
   (with-php-mode-test ("issue-19.php")
     (indent-region (point-min) (point-max))
     (goto-char (point-min))


### PR DESCRIPTION
This automates the testing of files in the `tests` directory. Currently, issues 9, 14, and 19 fail under `GNU Emacs 24.2.1 (i686-pc-linux-gnu, GTK+ Version 2.20.1) of 2012-09-05`, so they are marked as expected failures so that all tests pass. Once the underlying bugs are fixed, the expectation of failure should be removed.

This closes ejmr/php-mode#60
