### PR TITLE
Define `php-mode-map` in a `defvar`, as is the recommended style.

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -545,6 +545,30 @@ This is was done due to the problem reported here:
             (delete-char (* (funcall count-func 'arglist-cont-nonempty syntax)
                             c-basic-offset)))))))
 
+(defvar php-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map [menu-bar php]
+      (cons "PHP" (make-sparse-keymap "PHP")))
+
+    (define-key map [menu-bar php complete-function]
+      '("Complete function name" . php-complete-function))
+    (define-key map [menu-bar php browse-manual]
+      '("Browse manual" . php-browse-manual))
+    (define-key map [menu-bar php search-documentation]
+      '("Search documentation" . php-search-documentation))
+
+    (define-key map [(control c) (control f)] 'php-search-documentation)
+    (define-key map [(meta tab)] 'php-complete-function)
+    (define-key map [(control c) (control m)] 'php-browse-manual)
+    (define-key map [(control .)] 'php-show-arglist)
+    (define-key map [(control c) (control r)] 'php-send-region)
+    ;; Use the Emacs standard indentation binding. This may upset c-mode
+    ;; which does not follow this at the moment, but I see no better
+    ;; choice.
+    (define-key map [tab] 'indent-for-tab-command)
+    map)
+  "Keymap for `php-mode'")
+
 ;;;###autoload
 (define-derived-mode php-mode c-mode "PHP"
   "Major mode for editing PHP code.\n\n\\{php-mode-map}"
@@ -647,22 +671,6 @@ This is was done due to the problem reported here:
        "^\\s-*function\\s-+&?\\s-*\\(\\(\\sw\\|\\s_\\)+\\)\\s-*")
   (set (make-local-variable 'add-log-current-defun-header-regexp)
        php-beginning-of-defun-regexp))
-
-;; Make a menu keymap (with a prompt string)
-;; and make it the menu bar item's definition.
-(define-key php-mode-map [menu-bar] (make-sparse-keymap))
-(define-key php-mode-map [menu-bar php]
-  (cons "PHP" (make-sparse-keymap "PHP")))
-
-;; Define specific subcommands in this menu.
-(define-key php-mode-map [menu-bar php complete-function]
-  '("Complete function name" . php-complete-function))
-(define-key php-mode-map
-  [menu-bar php browse-manual]
-  '("Browse manual" . php-browse-manual))
-(define-key php-mode-map
-  [menu-bar php search-documentation]
-  '("Search documentation" . php-search-documentation))
 
 ;; Define function name completion function
 (defvar php-completion-table nil
@@ -831,30 +839,6 @@ searching the PHP website."
   (interactive)
   (browse-url php-manual-url))
 
-;; Define shortcut
-(define-key php-mode-map
-  "\C-c\C-f"
-  'php-search-documentation)
-
-;; Define shortcut
-(define-key php-mode-map
-  [(meta tab)]
-  'php-complete-function)
-
-;; Define shortcut
-(define-key php-mode-map
-  "\C-c\C-m"
-  'php-browse-manual)
-
-;; Define shortcut
-(define-key php-mode-map
-  '[(control .)]
-  'php-show-arglist)
-
-;; Use the Emacs standard indentation binding. This may upset c-mode
-;; which does not follow this at the moment, but I see no better
-;; choice.
-(define-key php-mode-map [?\t] 'indent-for-tab-command)
 
 (defconst php-constants
   (eval-when-compile
@@ -1669,8 +1653,6 @@ The output will appear in the buffer *PHP*."
                                (substring code 5)
                              code)))
       (call-process "php" nil php-buffer nil "-r" (clean-php-code code)))))
-
-(define-key php-mode-map "\C-c\C-r" 'php-send-region)
 
 
 (defface php-annotations-annotation-face '((t . (:inherit 'font-lock-constant-face)))


### PR DESCRIPTION
See [Tips for Defining(elisp)](http://www.gnu.org/software/emacs/manual/html_node/elisp/Tips-for-Defining.html).
