### PR TITLE
Do not override font-lock for case/continue/break labels

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1462,7 +1462,7 @@ searching the PHP website."
 
    ;; Fontify keywords and targets, and case default tags.
    (list "\\<\\(break\\|case\\|continue\\)\\>\\s-+\\(-?\\sw+\\)?"
-         '(1 font-lock-keyword-face) '(2 font-lock-constant-face t t))
+         '(1 font-lock-keyword-face) '(2 font-lock-constant-face keep t))
    ;; This must come after the one for keywords and targets.
    '(":" ("^\\s-+\\(\\sw+\\)\\s-+\\s-+$"
           (beginning-of-line) (end-of-line)


### PR DESCRIPTION
This prevents us from displaying words following "case", "continue",
and "break" in unexpected faces inside comments.

Consider this (meaningless) comment haiku:

```
// continue to move
// I will break all of the things
// in case of failure
```

Before this commit is applied, "to", "all", and "of" are displayed with unexpected coloration.

Based on a little experimentation and [this page](http://www.gnu.org/software/emacs/manual/html_node/elisp/Search_002dbased-Fontification.html#Search_002dbased-Fontification), I believe this patch fixes the issue, but I might be mistaken.
