### PR TITLE
Correct behavior of `delete-indentation`.

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -175,3 +175,25 @@ The closing brace and parenthesis should be at column 0."
 If the bug has been fixed, indenting the buffer should not cause
 an error."
   (with-php-mode-test ("issue-42.php" :indent t)))
+
+(ert-deftest php-mode-test-issue-73 ()
+  "The `delete-indentation' function should work properly for PHP.
+ This means modifying the logic of `fixup-whitespace' so that it
+ eliminates spaces before ',', ';', '->' amd '::' and after '->' and
+ '::'."
+  (with-php-mode-test ("issue-73.php")
+    (when (search-forward "# Correct" nil t)
+      (forward-line 1)
+      (let ((correct-line (thing-at-point 'line)))
+        (while (search-forward "# Test" nil t)
+          (forward-line 1)
+          (let ((current-line (line-number-at-pos)))
+            (catch 'eob
+              (while (not (looking-at-p "$"))
+                (unless (zerop (forward-line 1))
+                  (throw 'eob t))))
+            (forward-line -1)
+            (while (not (eq (line-number-at-pos) current-line))
+              (delete-indentation))
+            (beginning-of-line)
+            (should (string= (thing-at-point 'line) correct-line))))))))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1711,6 +1711,22 @@ The output will appear in the buffer *PHP*."
 
 
 
+;;; Correct the behavior of `delete-indentation' by modifying the
+;;; logic of `fixup-whitespace'.
+(defadvice fixup-whitespace (after php-mode-fixup-whitespace)
+  "Remove whitespace before certain characters in PHP mode."
+  (let* ((no-behind-space ";\\|,\\|->\\|::")
+         (no-front-space "->\\|::"))
+    (when (and (eq major-mode 'php-mode)
+               (or (looking-at-p (concat " \\(" no-behind-space "\\)"))
+                   (save-excursion
+                     (forward-char -2)
+                     (looking-at-p no-front-space))))
+      (delete-char 1))))
+
+(ad-activate 'fixup-whitespace)
+
+
 ;;;###autoload
 (dolist (pattern '("\\.php[s345t]?\\'" "\\.phtml\\'"))
   (add-to-list 'auto-mode-alist `(,pattern . php-mode)))

--- a/tests/issue-73.php
+++ b/tests/issue-73.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Github Issue:    https://github.com/ejmr/php-mode/issues/73
+ *
+ * The `delete-indentation' function should work properly for PHP.
+ * This means modifying the logic of `fixup-whitespace' so that it
+ * eliminates spaces before ',', ';', '->' amd '::' and after '->' and
+ * '::'.
+ */
+
+# Correct
+TEST::di->set('config', function () use ($config);
+
+# Test
+TEST
+::
+di->set('config', function () use ($config);
+
+# Test
+TEST::di
+->
+set('config', function () use ($config);
+
+# Test
+TEST::di->set('config'
+, function () use ($config);
+
+# Test
+TEST::di->set('config', function () use ($config)
+;


### PR DESCRIPTION
Issue #73 

The `delete-indentation` function should work properly for PHP.  This
means modifying the logic of `fixup-whitespace` so that it eliminates
spaces before ',', ';', '->' amd '::' and after '->' and '::'.
