### PR TITLE
Added function `php-lineup-arglist`

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -356,7 +356,7 @@ working with Wordpress."
 (c-add-style
  "symfony2"
  '((c-basic-offset . 4)
-   (c-offsets-alist . ((arglist-cont . 0)
+   (c-offsets-alist . ((arglist-cont . php-lineup-arglist)
                        (arglist-intro . php-lineup-arglist-intro)
                        (arglist-close . php-lineup-arglist-close)
                        (topmost-intro-cont . c-lineup-cascaded-calls)
@@ -578,6 +578,11 @@ This is was done due to the problem reported here:
 
 (c-set-offset 'arglist-intro 'php-lineup-arglist-intro)
 (c-set-offset 'arglist-close 'php-lineup-arglist-close)
+
+(defun php-lineup-arglist (langelem)
+  (save-excursion
+    (beginning-of-line)
+    (if (looking-at-p "\\s-*->") '+ 0)))
 
 (defun php-lineup-hanging-semicolon (langelem)
   (save-excursion


### PR DESCRIPTION
I added this function to allow for variable indentation inside arglists. I did
this so the Symfony2 style would format a function call like this:

``` php
$this->factory->addType(
    $this
        ->getMockBuilder('Symfony\Bridge\Doctrine\Form\Type\EntityType')
        ->disableOriginalConstructor()
        ->getMock(),
    $next
);
```

instead of this:

``` php
$this->factory->addType(
    $this
    ->getMockBuilder('Symfony\Bridge\Doctrine\Form\Type\EntityType')
    ->disableOriginalConstructor()
    ->getMock(),
    $next
);
```

It's possible this could be wanted behavior in the other styles.
