### PR TITLE
Load theme bug

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -277,16 +277,17 @@ This variable can take one of the following symbol values:
   :initialize 'custom-initialize-default)
 
 (defun php-mode-custom-coding-style-set (sym value)
-  (set         sym value)
-  (set-default sym value)
-  (cond ((eq value 'pear)
-         (php-enable-pear-coding-style))
-        ((eq value 'drupal)
-         (php-enable-drupal-coding-style))
-        ((eq value 'wordpress)
-         (php-enable-wordpress-coding-style))
-        ((eq value 'symfony2)
-         (php-enable-symfony2-coding-style))))
+  (when (eq major-mode 'php-mode)
+    (set         sym value)
+    (set-default sym value)
+    (cond ((eq value 'pear)
+           (php-enable-pear-coding-style))
+          ((eq value 'drupal)
+           (php-enable-drupal-coding-style))
+          ((eq value 'wordpress)
+           (php-enable-wordpress-coding-style))
+          ((eq value 'symfony2)
+           (php-enable-symfony2-coding-style)))))
 
 
 


### PR DESCRIPTION
If you have `php-mode-coding-style` set and you run `load-theme`, it
calls `php-mode-custom-coding-style-set` from
`custom-theme-recalc-variable`.  This happens regardless of what type
of buffer you are in, so if you are in a buffer whose major mode is
not based on `cc-mode`, you can get an error like this:

```
Debugger entered--Lisp error: (error "Buffer  *temp* is not a CC Mode buffer (c-set-style)")
  signal(error ("Buffer  *temp* is not a CC Mode buffer (c-set-style)"))
  error("Buffer %s is not a CC Mode buffer (c-set-style)" " *temp*")
  c-set-style("symfony2")
  php-enable-symfony2-coding-style()
  php-mode-custom-coding-style-set(php-mode-coding-style symfony2)
  custom-theme-recalc-variable(php-mode-coding-style)
  enable-theme(user)
  enable-theme(solarized-dark)
  load-theme(solarized-dark)
  eval((load-theme (quote solarized-dark)) nil)
  eval-last-sexp-1(nil)
  eval-last-sexp(nil)
  call-interactively(eval-last-sexp nil nil)
```

 This patch makes `php-mode-custom-coding-style-set` check to make
 sure it's in a `php-mode` buffer.
