### PR TITLE
PSR standards compliance in Symfony2 coding style

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -367,7 +367,7 @@ working with Wordpress."
                        (arglist-close . php-lineup-arglist-close)
                        (topmost-intro-cont . c-lineup-cascaded-calls)
                        (brace-list-intro . +)
-                       (brace-list-entry . c-lineup-cascaded-calls)
+                       (brace-list-entry . 4)
                        (case-label . 4)
                        (defun-close . 0)
                        (defun-block-intro . +)


### PR DESCRIPTION
brace-list-entry whould have offset set to 4 according to PSR
