### PR TITLE
Display and enforce PSR-2 whitespace/newline styles

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -444,9 +444,9 @@ working with Symfony2."
   (setq tab-width 4
         indent-tabs-mode nil)
   (c-set-style "psr2")
-  ;; Undo drupal coding style whitespace effects
-  (setq show-trailing-whitespace nil)
-  (remove-hook 'before-save-hook 'delete-trailing-whitespace t))
+  (set (make-local-variable 'require-final-newline) t)
+  (set (make-local-variable 'show-trailing-whitespace) t)
+  (add-hook 'before-save-hook 'delete-trailing-whitespace nil t))
 
 
 (defun php-mode-version ()


### PR DESCRIPTION
This patch does three things:
- Displays trailing whitespaces
- Deletes trailing whitespaces on save -- This includes empty lines at end of file.
- Adds trailing newline at end of file if there is none.

Also noticed in a comment somewhere that `require-final-newline` could cause trouble. This is not entirely true.

If you end your file with `?>\n` it wont be a problem, but if you end it with `?>\n\n` it will be.

But `delete-trailing-whitespace` will also clear empty lines at the end of the file if they are empty. So it won't cause any trouble as far as I can see.

PSR-2 also states that you shouldn't have any whitespaces at ends of lines, and the PHP CodeSniffer utility that people use requires you to have one newline at end of files.

The first patch was indent, this is whitespaces and newlines. PSR-2 got more rules about it, but that's alot more work to fix... Some day maybe.
