### PR TITLE
Fix indent of comments starting at the beginning of the line

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -436,7 +436,8 @@ working with Symfony2."
                        (knr-argdecl . [0])
                        (arglist-cont-nonempty . c-lineup-cascaded-calls)
                        (statement-cont . +)
-                       (case-label . +)))))
+                       (case-label . +)
+                       (comment-intro . 0)))))
 
 (defun php-enable-psr2-coding-style ()
   "Makes php-mode use coding styles defined by PSR-2"


### PR DESCRIPTION
If you try to indent the comment, it won't indent. even if it should in this example:

``` php
<?php

if (true) {
// body
}
```

But if we put a space in front of the comment so it looks like this:

``` php
<?php

if (true) {
 // body
}
```

The comment get's indented to 4 spaces.

This patch fixes that it gets indented anyways :)

(Nothing in PSR-2 states that it _have_ to be like this, but it's nice and I think all the coding styles should adopt this patch)
