### PR TITLE
Tweak PSR-2 style by adding (substatement-open . 0)

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -436,6 +436,7 @@ working with Symfony2."
                        (knr-argdecl . [0])
                        (arglist-cont-nonempty . c-lineup-cascaded-calls)
                        (statement-cont . +)
+                       (substatement-open . 0)
                        (case-label . +)
                        (comment-intro . 0)))))
 
@@ -1576,7 +1577,7 @@ searching the PHP website."
       "PHP_SESSION_DISABLED"
       "PHP_SESSION_NONE"
       "PHP_SESSION_ACTIVE"
-      
+
       ;; IMAP constants
       "NIL"
       "OP_DEBUG"


### PR DESCRIPTION
PSR-2 states:

  Opening braces for control structures MUST go on the same line, and
  closing braces MUST go on the next line after the body.

However, in the event that the brace does go on the same line, do not
indent it.
