### PR TITLE
Do not override variable tab-width when indenting with spaces.

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -326,8 +326,7 @@ This variable can take one of the following symbol values:
   "Sets up php-mode to use the coding styles preferred for PEAR
 code and modules."
   (interactive)
-  (setq tab-width 4
-        indent-tabs-mode nil)
+  (setq indent-tabs-mode nil)
   (c-set-style "pear")
   ;; Undo drupal coding style whitespace effects
   (setq show-trailing-whitespace nil)
@@ -352,8 +351,7 @@ code and modules."
   "Makes php-mode use coding styles that are preferable for
 working with Drupal."
   (interactive)
-  (setq tab-width 2
-        indent-tabs-mode nil
+  (setq indent-tabs-mode nil
         fill-column 78
         show-trailing-whitespace t)
   (add-hook 'before-save-hook 'delete-trailing-whitespace nil t)
@@ -414,7 +412,6 @@ working with Symfony2."
   (interactive)
   (setq indent-tabs-mode nil
         fill-column 78
-        tab-width 4
         c-indent-comments-syntactically-p t
         require-final-newline t)
   (c-set-style "symfony2")
@@ -443,8 +440,7 @@ working with Symfony2."
 (defun php-enable-psr2-coding-style ()
   "Makes php-mode use coding styles defined by PSR-2"
   (interactive)
-  (setq tab-width 4
-        indent-tabs-mode nil)
+  (setq indent-tabs-mode nil)
   (c-set-style "psr2")
   (set (make-local-variable 'require-final-newline) t)
   (set (make-local-variable 'show-trailing-whitespace) t)


### PR DESCRIPTION
The number of spaces to indent is controlled by the correctly set
variable c-offset-width. The value of tab-width does not influence
this. When indent-tabs-mode is nil, indentation is always acheived
using spaces, not tabs. The various modes set this correctly. However,
the modes that indent using spaces also override tab-width which might
undo a user's set value.

As an example, a user may prefer a literal tab (not code indentation)
be rendered as 8 spaces. And so this user would set tab-width to 8 in
init.el. All PHP modes override this value even when not using tabs
for indentation. This mean's the user's preferred tab width is altered
for no gain.

I prefer using tab-width 8 so I can quickly see when code is
incorrectly indented with tabs instead of spaces. The overriding of
this value breaks this for me. Of course, I workaround this by
re-setting tab-width in hooks, but why put the user through this in
the first place.

Coding styles that indent using tab (such as wordpress) remain
unaltered.
