### PR TITLE
Fix failing test case for issue 124

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -240,7 +240,7 @@ style from Drupal."
 (ert-deftest php-mode-test-issue-124 ()
   "Proper syntax propertizing when a quote appears in a heredoc."
   (with-php-mode-test ("issue-124.php" :indent t)
-     (search-forward "Heredoc")
+     (search-forward "Start of heredoc")
      ;; The heredoc should be recognized as a string.
      (dolist (syntax (c-guess-basic-syntax))
        (should (eq (car syntax) 'string)))

--- a/tests/issue-124.php
+++ b/tests/issue-124.php
@@ -11,7 +11,7 @@
  */
 
 $foo = <<<EOT
-Heredoc with a ' inside.
+Start of heredoc with a ' inside.
 EOT;
 
 function bar()


### PR DESCRIPTION
The test failed to search-forward to the heredoc and instead matched the
string 'heredoc' inside the comment.
