### PR TITLE
Enable case sensitive search in 'with-php-mode-test'

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -100,7 +100,8 @@ The test will use the PEAR style by default."
           '(should (reduce (lambda (l r) (and l r))
                            (php-mode-test-process-magics))))
      (goto-char (point-min))
-     ,@body))
+     (let ((case-fold-search nil))
+       ,@body)))
 
 (ert-deftest php-mode-test-issue-8 ()
   "Annotation highlighting."


### PR DESCRIPTION
We can avoid 7fac0db190797c9ae15b4a3028192824c4e8301f case with this fix.
