### PR TITLE
Improve Makefile for testing various Emacs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-EMACS = emacs -Q -batch -L .
+EMACS ?= emacs
 ELS = php-mode.el php-mode-test.el
 ELCS = $(ELS:.el=.elc)
 
 %.elc: %.el
-	$(EMACS) -f batch-byte-compile $<
+	$(EMACS) -Q -batch -L . -f batch-byte-compile $<
 
 all: $(ELCS)
 
@@ -22,6 +22,6 @@ clean:
 # for an example of using a script like this with the 'git bisect run'
 # command.
 test: $(ELCS)
-	$(EMACS) -l php-mode-test.el -f ert-run-tests-batch-and-exit
+	$(EMACS) -Q -batch -L . -l php-mode-test.el -f ert-run-tests-batch-and-exit
 
 .PHONY: all clean test


### PR DESCRIPTION
We can test various emacs easily by this fix like.

```
% EMACS=emacs-24.3 make test
% EMACS=emacs-24.1 make test
```
