### PR TITLE
Cleanup c-offsets-alist for drupal and wordpress

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -442,7 +442,7 @@ This variable can take one of the following symbol values:
   ;; falls back to java, so no need to specify the language
   php (append (remove ">>>=" (c-lang-const c-assignment-operators))
               '(".=")))
- 
+
 (c-lang-defconst beginning-of-defun-function
   php 'php-beginning-of-defun)
 
@@ -566,19 +566,18 @@ PHP does not have an \"enum\"-like keyword."
  "php"
  '((c-basic-offset . 4)
    (c-doc-comment-style . javadoc)
-   (c-offsets-alist . ((inline-open . 0)
-                       (inlambda . 0)
-                       (class-open . -)
-                       (statement-cont . (first c-lineup-cascaded-calls +))
-                       (topmost-intro-cont . (first c-lineup-cascaded-calls +))
+   (c-offsets-alist . ((arglist-close . php-lineup-arglist-close)
                        (arglist-cont . (first c-lineup-cascaded-calls 0))
-                       (statement-block-intro . +)
-                       (substatement-open . 0)
-                       (case-label . +)
-                       (label . +)
                        (arglist-cont-nonempty . (first c-lineup-cascaded-calls c-lineup-arglist))
                        (arglist-intro . php-lineup-arglist-intro)
-                       (arglist-close . php-lineup-arglist-close)))))
+                       (case-label . +)
+                       (class-open . -)
+                       (inlambda . 0)
+                       (inline-open . 0)
+                       (label . +)
+                       (statement-cont . (first c-lineup-cascaded-calls +))
+                       (substatement-open . 0)
+                       (topmost-intro-cont . (first c-lineup-cascaded-calls +))))))
 
 (add-to-list 'c-default-style '(php-mode . "php"))
 
@@ -603,12 +602,7 @@ code and modules."
 (c-add-style
  "drupal"
  '("php"
-   (c-basic-offset . 2)
-   (c-offsets-alist . ((arglist-close . 0)
-                       (arglist-intro . +)
-                       (arglist-cont-nonempty . c-lineup-math)
-                       (statement-cont . +)
-                       (topmost-intro-cont . +)))))
+   (c-basic-offset . 2)))
 
 (defun php-enable-drupal-coding-style ()
   "Makes php-mode use coding styles that are preferable for
@@ -624,14 +618,7 @@ working with Drupal."
 (c-add-style
   "wordpress"
   '("php"
-    (c-basic-offset . 4)
-    (c-offsets-alist . ((arglist-cont . 0)
-                        (arglist-intro . +)
-                        (case-label . 2)
-                        (arglist-close . 0)
-                        (defun-close . 0)
-                        (defun-block-intro . +)
-                        (statement-cont . +)))))
+    (c-basic-offset . 4)))
 
 (defun php-enable-wordpress-coding-style ()
   "Makes php-mode use coding styles that are preferable for


### PR DESCRIPTION
Recent changes broke the indentation inside arglists for Drupal and
wordpress. Restoring the old situation by literally copying the old
offsets-alist is not an option for the following reasons:
- we now inherit c-offsets-alist from the base-style (php), so we don't
  want to duplicate a different list for Drupal unless it actually needs
  completely different indentation rules.
- old situation had bogus definitions: elements defined twice, elements
  defined to return default value or usage of `first' where the first
  defun always returns an offset.
- old definitions contain rules not required by the standard, like 2
  spaces for case labels for wordpress. If some people need this
  behaviour we should document how to configure it, and if I'm mistaken
  it's easy to restore.
- old definitions contain unclear rules like for K&R regions, if those
  do make sense in php-mode, I'd like to find out in what use case so
  we can test it.

Looking at the standards, there seems to be no need for
different indentation rules for drupal/wordpress/pear/psr2 so they now
all use the same c-offsets-alist.

Other changes in this commit:
- c-offsets-alist is now alphabetically sorted
- base style (php) now only defines elements that are actually
  different from the default

Ideas for future improvements related to coding styles:
- there's no reason to show trailing whitespace by default for Drupal,
  and not other styles. Make this default to on or off and make it
  configurable, regardless of the used style.
- same goes for automatic whitespace removal, this makes as much sense
  for PSR2 as it does for Drupal.
- this also applies to the lineup-cascaded calls behaviour and to
  lesser extent hanging semicolons, no style guide specifies how to
  lineup chained methods, so it makes no sense to have it enabled for
  psr2 and (for example) disabled for pear (it's currently on for all
  styles but the user can disable it by changing the c-offsets-alist -
  which is probably hard to figure out how to do for many users)
- remove symfony2 style (psr2 should suffice)
- better documentation (issue #131)
