### PR TITLE
Add missing language constructs to php-mode

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -401,4 +401,18 @@ style from Drupal."
     (goto-char (match-beginning 0))
     (should-not (get-text-property (point) 'face))))
 
+(ert-deftest php-mode-test-language-constructs()
+  "Test highlighting of language constructs and reserved keywords"
+  (with-php-mode-test ("language-constructs.php")
+                      (while (search-forward "ClassName" nil t)
+                        (backward-char)
+                        (should (eq 'font-lock-type-face
+                                    (get-text-property (point) 'face)))))
+  (with-php-mode-test ("language-constructs.php")
+                      (search-forward "Start:")
+                      (while (not (= (line-number-at-pos) (count-lines (point-min) (point-max))))
+                        (next-line)
+                        (should (eq 'font-lock-keyword-face
+                                    (get-text-property (point) 'face))))))
+
 ;;; php-mode-test.el ends here

--- a/php-mode.el
+++ b/php-mode.el
@@ -480,7 +480,7 @@ PHP does not have an \"enum\"-like keyword."
   php '("implements" "extends"))
 
 (c-lang-defconst c-type-list-kwds
-  php '("new" "use" "as" "implements" "extends" "namespace"))
+  php '("new" "use" "as" "implements" "extends" "namespace" "instanceof" "insteadof"))
 
 (c-lang-defconst c-ref-list-kwds
   php nil)
@@ -490,7 +490,8 @@ PHP does not have an \"enum\"-like keyword."
               (remove "synchronized" (c-lang-const c-block-stmt-2-kwds))))
 
 (c-lang-defconst c-simple-stmt-kwds
-  php (append '("include" "include_once" "require" "require_once" "echo" "print")
+  php (append '("include" "include_once" "require" "require_once"
+                "echo" "print" "die" "exit")
               (c-lang-const c-simple-stmt-kwds)))
 
 (c-lang-defconst c-constant-kwds
@@ -503,24 +504,14 @@ PHP does not have an \"enum\"-like keyword."
 
 (c-lang-defconst c-other-kwds
   "Keywords not accounted for by any other `*-kwds' language constant."
-  php '("abstract"
+  php '(
+    "__halt_compiler"
     "and"
     "array"
-    "break"
-    "catch all"
-    "catch"
+    "callable"
     "clone"
-    "const"
-    "continue"
-    "declare"
     "default"
-    "die"
-    "do"
-    "echo"
-    "else"
-    "elseif"
     "empty"
-    "encoding"
     "enddeclare"
     "endfor"
     "endforeach"
@@ -528,32 +519,19 @@ PHP does not have an \"enum\"-like keyword."
     "endswitch"
     "endwhile"
     "eval"
-    "exit"
-    "final"
-    "finally"
-    "for"
-    "foreach"
-    "function"
     "global"
-    "if"
-    "include"
-    "include_once"
     "isset"
     "list"
     "or"
-    "require"
-    "require_once"
-    "return"
     "static"
-    "switch"
-    "throw"
-    "ticks"
-    "try"
     "unset"
     "var"
-    "while"
     "xor"
-    "yield"))
+    "yield"
+
+    ;; technically not reserved keywords, but "declare directives"
+    "encoding"
+    "ticks"))
 
 ;; PHP does not have <> templates/generics
 (c-lang-defconst c-recognize-<>-arglists

--- a/tests/language-constructs.php
+++ b/tests/language-constructs.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Test highlighting of language constructs and reserved keywords
+ *
+ * This test is based on http://php.net/manual/en/reserved.keywords.php and should
+ * be updated from the manual when new PHP versions arrive. Built-in functions are
+ * not treated differently by php-mode than regular function calls: that means
+ * they are not highlighted. Only language constructs like print/die and reserved
+ * keywords are, and those are tested here.
+ */
+
+// Start:
+__halt_compiler();
+abstract;
+and;
+array();
+as;
+break;
+callable;
+case;
+catch;
+class ClassName;
+clone;
+const;
+continue;
+declare;
+default;
+die();
+do;
+echo;
+else;
+elseif;
+empty();
+enddeclare;
+endfor;
+endforeach;
+endif;
+endswitch;
+endwhile;
+eval();
+exit();
+extends ClassName;
+final;
+finally;
+for;
+foreach;
+function;
+global;
+goto;
+if;
+implements ClassName;
+include;
+include_once;
+instanceof ClassName;
+insteadof ClassName;
+interface ClassName;
+isset();
+list();
+namespace ClassName;
+new ClassName;
+print;
+private;
+protected;
+public;
+require;
+require_once;
+return;
+static;
+switch;
+throw;
+trait ClassName;
+try;
+unset();
+use ClassName;
+var;
+while;
+xor;
+yield;


### PR DESCRIPTION
A new test contains all language constructs and reserved keywords from
the PHP 5.6 manual. The test checks that they all get the
keyword-face. In addition to that, for keywords that preceed a type
identifier like instanceof and insteadof, it is checked that the
identifier gets the type-face.

Some keywords in c-other-kwds were already specified in another *-kwds,
those are now removed. Keywords added in this commit are: insteadof,
callable (the type hint now works just like 'array') and __halt_compiler().

This resolves issue #180.
