### PR TITLE
Correct wrongly resolved merge conflict for "as" (was: #191)

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -480,7 +480,7 @@ PHP does not have an \"enum\"-like keyword."
   php '("implements" "extends"))
 
 (c-lang-defconst c-type-list-kwds
-  php '("new" "use" "as" "implements" "extends" "namespace" "instanceof" "insteadof"))
+  php '("new" "use" "implements" "extends" "namespace" "instanceof" "insteadof"))
 
 (c-lang-defconst c-ref-list-kwds
   php nil)


### PR DESCRIPTION
Fix was merged in d117a47 but the test case for issue-178 still failed,
this commit makes all different uses for "as" behave properly.
