### PR TITLE
Assert Emacs version in Travis CI tests

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -2,6 +2,7 @@
 
 ;; Copyright (C) 2013 Daniel Hackney
 ;;               2014, 2015 Eric James Michael Ritz
+;;               2017 Tim Landscheidt
 
 ;; Author: Daniel Hackney <dan@haxney.org>
 ;; URL: https://github.com/ejmr/php-mode
@@ -122,6 +123,21 @@ run with specific customizations set."
      (goto-char (point-min))
      (let ((case-fold-search nil))
        ,@body)))
+
+(ert-deftest php-mode-test-emacs-version ()
+  "Emacs version is the requested one."
+  ;; Ideally, we would use skip-unless here, but that is only
+  ;; available in 24.4 and newer.
+  (if (getenv "EMACS_VERSION")
+      (should
+       (string=
+        (getenv "EMACS_VERSION")
+        ;; Testing for a fourth field in emacs-version is somewhat of
+        ;; a kludge to determine if we are running a snapshot version,
+        ;; but it seems to work.
+        (if (= (length (version-to-list emacs-version)) 4)
+            "emacs-snapshot"
+          (format "emacs-%d.%d-bin" emacs-major-version emacs-minor-version))))))
 
 (ert-deftest php-mode-test-namespace-block ()
   "Proper indentation for classs and functions in namespace block."


### PR DESCRIPTION
The current Travis CI setup is very tolerant against failures to
install the requested Emacs version, falling back to the default
Emacs 24.3.1.  This can be very confusing when debugging errors
because the value for $EMACS_VERSION does not always correlate with
the actual Emacs version the tests were run against.

This change adds an assertion test that ensures that the actual Emacs
version the tests are running against is the one requested by
$EMACS_VERSION.  For emacs-snapshot, as there is no property "this is
a development snapshot", this change relies on emacs-version having
four elements (e. g., "26.0.50.1").