### PR TITLE
README: Mention the FeatHub page for feature requests

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -22,7 +22,7 @@ PHP 5.4以降を開発しやすくするための機能をアップデートす�
 
 1. USAMI Kenta (@zonuexe)
 
-[PHPモードのGitHubプロジェクト](https://github.com/emacs-php/php-mode)にissueを作成してバグ報告や機能リクエストを送ってください。
+[PHPモードのGitHubプロジェクト](https://github.com/emacs-php/php-mode)にissueを作成してバグ報告や機能リクエストを送ってください。或いは[PHPのスイート](https://github.com/emacs-php/php-suite)の[FeatHubページ](https://feathub.com/emacs-php/php-suite)に機能リクエストを送ってもいいです。
 
 インストール
 ------------

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The current maintainer is:
 
 1. USAMI Kenta (@zonuexe)
 
-Please submit any bug reports or feature requests by creating issues on [the GitHub page for PHP Mode](https://github.com/emacs-php/php-mode).
+Please submit any bug reports or feature requests by creating issues on [the GitHub page for PHP Mode](https://github.com/emacs-php/php-mode).  Alternatively you may also request features via [the FeatHub page](https://feathub.com/emacs-php/php-suite) for the entire [PHP suite for GNU Emacs](https://github.com/emacs-php/php-suite).
 
 
 Installation


### PR DESCRIPTION
This patch updates both READMEs with a mention of the official
FeatHub page for the GNU Emacs PHP Suite.  It is highly likely that
users will continue to request features via GitHub itself.  However,
since we discussed using FeatHub (see link below) we need to let users
know that it exists.  If we do not then, obviously, no one will use it.

The changes do not describe exactly *how* users should make requests
through FeatHub because we currently have no defined workflow
involving FeatHub.  In fact, it is not even certain that we will
end up using FeatHub at all; eventually we may very well prefer that
users continue to make feature requests through GitHub's mechanisms.
But we cannot accurately judge the merits of FeatHub if no one is
aware it even exists.

Therefore this patch is a small step towards helping us decide on
the best way to collect user feedback, particularly with regard to
new features people want to see in PHP Mode and its related projects.

See-also: https://github.com/emacs-php/php-suite/issues/5
Signed-off-by: Eric James Michael Ritz <ejmr@no.current.address>