### PR TITLE
Add a "Hall of Fame" to the contributors list

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ PHP Mode uses the [GNU General Public License 3](http://www.gnu.org/copyleft/gpl
 Contributors
 ------------
 
+[![](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/images/0)](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/links/0)[![](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/images/1)](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/links/1)[![](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/images/2)](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/links/2)[![](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/images/3)](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/links/3)[![](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/images/4)](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/links/4)[![](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/images/5)](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/links/5)[![](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/images/6)](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/links/6)[![](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/images/7)](https://sourcerer.io/fame/ejmr/emacs-php/php-mode/links/7)
+
 In chronological order:
 
 1. Juanjo


### PR DESCRIPTION
This patch makes use of

	https://github.com/sourcerer-io/hall-of-fame

to display a Hall of Fame for the top contributors.  There are two
purposes to this addition:

1. To show gratitude.
2. To hopefully encourage more contributions.

Admittedly there is some concern this may invite developers to
"game" the system, i.e. trying "win" the Hall of Fame by submitting
more patches.  In other words, it could invite a problem of quantity
over quality.  However, I have fath that the emacs-php community is
more mature than that.

This patch does not update the Japanese version of the README since
it explicitly links to the list of contributors in the English version.

Special-thanks: @emacs-php
Special-thanks: Every contributor ever
Signed-off-by: Eric James Michael Ritz <ejmr@no.current.address>