### PR TITLE
WIP: Release 1.20.0

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,4 +1,4 @@
-(package "php-mode" "1.19.1" "Major mode for editing PHP code")
+(package "php-mode" "1.20.0" "Major mode for editing PHP code")
 (source melpa)
 
 (package-file "php-mode.el")

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,35 @@
 
 All notable changes of the PHP Mode 1.19.1 release series are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [1.20.0] - 2018-12-07
+
+Start preparing for major refactoring in major mode.
+
+### Changed
+
+ * Improve code highlight
+    * Fix highlighting of callable keyword ([#471](https://github.com/emacs-php/php-mode/pull/471) by [@fabacino])
+    * Highlight the `?` character for nullable type hints and return types ([#482](https://github.com/emacs-php/php-mode/pull/482) by [@fabacino])
+ * Modify "customize group" and variables
+    * Add php-mode group and some variables belong to new group ([#486](https://github.com/emacs-php/php-mode/pull/486))
+      * `php-default-face` → `php-mode-default-face`
+      * `php-speedbar-config` → `'php-mode-speedbar-config`
+      * `php-template-compatibility` → `php-mode-template-compatibility`
+      * `php-lineup-cascaded-calls` → `php-mode-lineup-cascaded-calls`
+      * `php-extra-constants` → `php-mode-extra-constants`
+      * `php-do-not-use-semantic-imenu` → `php-mode-do-not-use-semantic-imenu`
+ * Modify documents and copyright
+    * Move the URL of Website to https://github.com/emacs-php/php-mode
+    * Add copyright notation about [Friends of Emacs-PHP development](https://github.com/emacs-php)
+    * Add a "Hall of Fame" to the contributors list ([#481](https://github.com/emacs-php/php-mode/pull/481) by [@ejmr] and thanks [@sergey48k](https://github.com/sergey48k) and [@sourcerer-io](https://github.com/sourcerer-io) project)
+ * Some refactors
+    * Fix style and suppress warning in compile [#485](https://github.com/emacs-php/php-mode/pull/485)
+
+<!--
+ * Divide `php-mode.el` into `php.el` and `php-helper.el` for refactor
+   *  With this change, we provide simple functions to other packages without loading `php-mode`.
+-->
+
 ## [1.19.1] - 2018-05-12
 
 ### Added
@@ -30,3 +59,6 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
 ## Before 1.19.0
 
 See [Changelog · emacs-php/php-mode Wiki](https://github.com/emacs-php/php-mode/wiki/Changelog).
+
+[@ejmr]: https://github.com/ejmr
+[@fabacino]: https://github.com/fabacino

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,7 +22,7 @@ PHP 5.4以降を開発しやすくするための機能をアップデートす�
 
 1. USAMI Kenta (@zonuexe)
 
-[PHPモードのGitHubプロジェクト](https://github.com/emacs-php/php-mode)にissueを作成してバグ報告や機能リクエストを送ってください。或いは[PHPのスイート](https://github.com/emacs-php/php-suite)の[FeatHubページ](https://feathub.com/emacs-php/php-suite)に機能リクエストを送ってもいいです。
+[PHP ModeのGitHubプロジェクト][php-mode]にissueを作成してバグ報告や機能リクエストを送ってください。あるいは[PHP suite][php-suite]の[FeatHubページ][feathub]に機能リクエストを送っても構いません。
 
 インストール
 ------------
@@ -353,3 +353,6 @@ PHPモードの改善に協力したすべての貢献者のリストは[README.
 [melpa-stable-link]: http://stable.melpa.org/#/php-mode
 [melpa-badge]: http://melpa.org/packages/php-mode-badge.svg
 [melpa-stable-badge]: http://stable.melpa.org/packages/php-mode-badge.svg
+[php-mode]: https://github.com/emacs-php/php-mode
+[php-suite]: https://github.com/emacs-php/php-suite
+[feathub]: https://feathub.com/emacs-php/php-suite

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The current maintainer is:
 
 1. USAMI Kenta (@zonuexe)
 
-Please submit any bug reports or feature requests by creating issues on [the GitHub page for PHP Mode](https://github.com/emacs-php/php-mode).  Alternatively you may also request features via [the FeatHub page](https://feathub.com/emacs-php/php-suite) for the entire [PHP suite for GNU Emacs](https://github.com/emacs-php/php-suite).
+Please submit any bug reports or feature requests by creating issues on [the GitHub page for PHP Mode][php-mode].  Alternatively you may also request features via [the FeatHub page][feathub] for the entire [PHP suite for GNU Emacs][php-suite].
 
 
 Installation
@@ -417,3 +417,6 @@ In chronological order:
 [melpa-stable-link]: http://stable.melpa.org/#/php-mode
 [melpa-badge]: http://melpa.org/packages/php-mode-badge.svg
 [melpa-stable-badge]: http://stable.melpa.org/packages/php-mode-badge.svg
+[php-mode]: https://github.com/emacs-php/php-mode
+[php-suite]: https://github.com/emacs-php/php-suite
+[feathub]: https://feathub.com/emacs-php/php-suite

--- a/php-mode.el
+++ b/php-mode.el
@@ -1,5 +1,6 @@
 ;;; php-mode.el --- Major mode for editing PHP code
 
+;; Copyright (C) 2018  Friends of Emacs-PHP development
 ;; Copyright (C) 1999, 2000, 2001, 2003, 2004 Turadg Aleahmad
 ;;               2008 Aaron S. Hawley
 ;;               2011, 2012, 2013, 2014, 2015, 2016, 2017 Eric James Michael Ritz

--- a/php-mode.el
+++ b/php-mode.el
@@ -9,14 +9,14 @@
 ;; Maintainer: USAMI Kenta <tadsan@zonu.me>
 ;; URL: https://github.com/emacs-php/php-mode
 ;; Keywords: languages php
-;; Version: 1.19.1
+;; Version: 1.20.0
 ;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
 ;; License: GPL-3.0-or-later
 
-(defconst php-mode-version-number "1.19.1"
+(defconst php-mode-version-number "1.20.0"
   "PHP Mode version number.")
 
-(defconst php-mode-modified "2018-08-28"
+(defconst php-mode-modified "2018-12-05"
   "PHP Mode build date.")
 
 ;; This file is free software; you can redistribute it and/or

--- a/php-project.el
+++ b/php-project.el
@@ -5,7 +5,7 @@
 ;; Author: USAMI Kenta <tadsan@zonu.me>
 ;; Keywords: tools, files
 ;; URL: https://github.com/emacs-php/php-mode
-;; Version: 1.19.1
+;; Version: 1.20.0
 ;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
 ;; License: GPL-3.0-or-later
 


### PR DESCRIPTION
## [1.20.0] - 2018-12-07

Start preparing for major refactoring in major mode.

### Changed

 * Improve code highlight
    * Fix highlighting of callable keyword (#471 by @fabacino)
    * Highlight the `?` character for nullable type hints and return types (#482 by @fabacino)
 * Modify "customize group" and variables
    * Add php-mode group and some variables belong to new group (#486)
      * `php-default-face` → `php-mode-default-face`
      * `php-speedbar-config` → `'php-mode-speedbar-config`
      * `php-template-compatibility` → `php-mode-template-compatibility`
      * `php-lineup-cascaded-calls` → `php-mode-lineup-cascaded-calls`
      * `php-extra-constants` → `php-mode-extra-constants`
      * `php-do-not-use-semantic-imenu` → `php-mode-do-not-use-semantic-imenu`
 * Modify documents and copyright
    * Move the URL of Website to https://github.com/emacs-php/php-mode
    * Add copyright notation about [Friends of Emacs-PHP development](https://github.com/emacs-php)
    * Add a "Hall of Fame" to the contributors list (#481 by @ejmr and thanks @sergey48k and @sourcerer-io project)
 * Some refactors
    * Fix style and suppress warning in compile #485)
