### PR TITLE
Release 1.21.0

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,4 +1,4 @@
-(package "php-mode" "1.20.0" "Major mode for editing PHP code")
+(package "php-mode" "1.21.0" "Major mode for editing PHP code")
 (source melpa)
 
 (package-file "php-mode.el")

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,23 @@
 
 All notable changes of the PHP Mode 1.19.1 release series are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [1.21.0] - 2019-01-09
+
+A minor change from the previous version, but this version has BC brake about `c-mode-hook`.
+
+### Added
+
+ * Add `php` customize group.
+   * This group is positioned above `php-mode`.
+   * This group was originally planned to be included in v1.20.0.
+ * Add `php-mode-disable-c-mode-hook` custom variable.
+   * Setting this variable to `nil` will restore the behavior of `c-mode-hook` up to the previous version.
+
+### Changed
+
+ * `php-mode` initialization no longer executes hooks for `c-mode`.
+   *  If you want to return to the same behavior as the conventional PHP-Mode, set `nil` to `php-mode-disable-c-mode-hook`.
+
 ## [1.20.0] - 2018-12-07
 
 Start preparing for major refactoring in major mode.

--- a/php-mode.el
+++ b/php-mode.el
@@ -1,6 +1,6 @@
 ;;; php-mode.el --- Major mode for editing PHP code
 
-;; Copyright (C) 2018  Friends of Emacs-PHP development
+;; Copyright (C) 2018-2019  Friends of Emacs-PHP development
 ;; Copyright (C) 1999, 2000, 2001, 2003, 2004 Turadg Aleahmad
 ;;               2008 Aaron S. Hawley
 ;;               2011, 2012, 2013, 2014, 2015, 2016, 2017 Eric James Michael Ritz
@@ -9,14 +9,14 @@
 ;; Maintainer: USAMI Kenta <tadsan@zonu.me>
 ;; URL: https://github.com/emacs-php/php-mode
 ;; Keywords: languages php
-;; Version: 1.20.0
+;; Version: 1.21.0
 ;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
 ;; License: GPL-3.0-or-later
 
-(defconst php-mode-version-number "1.20.0"
+(defconst php-mode-version-number "1.21.0"
   "PHP Mode version number.")
 
-(defconst php-mode-modified "2018-12-05"
+(defconst php-mode-modified "2019-01-09"
   "PHP Mode build date.")
 
 ;; This file is free software; you can redistribute it and/or
@@ -1264,6 +1264,8 @@ After setting the stylevars run hooks according to STYLENAME
   "Major mode for editing PHP code.
 
 \\{php-mode-map}"
+  ;; :after-hook (c-update-modeline)
+  ;; (setq abbrev-mode t)
   (when php-mode-disable-c-mode-hook
     (setq-local c-mode-hook nil)
     (setq-local java-mode-hook nil))

--- a/php-mode.el
+++ b/php-mode.el
@@ -418,7 +418,8 @@ This function may interfere with other hooks and other behaviors.
 In that case set to `NIL'."
   :type 'boolean)
 
-(defcustom php-mode-disable-parent-mode-hooks t
+(define-obsolete-variable-alias 'php-mode-disable-parent-mode-hooks 'php-mode-disable-c-mode-hook "1.21.0")
+(defcustom php-mode-disable-c-mode-hook t
   "When set to `T', do not run hooks of parent modes (`java-mode', `c-mode')."
   :type 'boolean
   :group 'php-mode)
@@ -1263,7 +1264,7 @@ After setting the stylevars run hooks according to STYLENAME
   "Major mode for editing PHP code.
 
 \\{php-mode-map}"
-  (when php-mode-disable-parent-mode-hooks
+  (when php-mode-disable-c-mode-hook
     (setq-local c-mode-hook nil)
     (setq-local java-mode-hook nil))
   (c-initialize-cc-mode t)

--- a/php-project.el
+++ b/php-project.el
@@ -1,11 +1,11 @@
 ;;; php-project.el --- Project support for PHP application  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2018  Friends of Emacs-PHP development
+;; Copyright (C) 2018-2019  Friends of Emacs-PHP development
 
 ;; Author: USAMI Kenta <tadsan@zonu.me>
 ;; Keywords: tools, files
 ;; URL: https://github.com/emacs-php/php-mode
-;; Version: 1.20.0
+;; Version: 1.21.0
 ;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
 ;; License: GPL-3.0-or-later
 


### PR DESCRIPTION
A minor change from the previous version, but this version has BC brake about `c-mode-hook`.

### Added

 * Add `php` customize group.
   * This group is positioned above `php-mode`.
   * This group was originally planned to be included in v1.20.0.
 * Add `php-mode-disable-c-mode-hook` custom variable.
   * Setting this variable to `nil` will restore the behavior of `c-mode-hook` up to the previous version.

### Changed

 * `php-mode` initialization no longer executes hooks for `c-mode`.
   *  If you want to return to the same behavior as the conventional PHP-Mode, set `nil` to `php-mode-disable-c-mode-hook`.
