### PR TITLE
Function php-beginning-of-defun should return non-nil on success

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,13 @@
 
 All notable changes of the PHP Mode 1.19.1 release series are documented in this file using the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [1.21.2]
+
+### Fixed
+
+ * Function `php-beginning-of-defun` should return non-nil on success
+ ([#503](https://github.com/emacs-php/php-mode/issues/503))
+
 ## [1.21.1] - 2019-04-01
 
 ### Changed

--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -949,4 +949,28 @@ as a keyword."
   (should (string= (abbreviate-file-name default-directory)
                    (php-project-get-root-dir))))
 
+(defun php-mode-test-in-function-p (&optional pos)
+  "Determine whether POS is inside a function.
+Meant for `php-mode-test-issue-503'."
+  (let (bof (pos (or pos (point))))
+    (save-excursion
+      (when (beginning-of-defun)
+        (setq bof (point))
+        (end-of-defun)
+        (and (> pos bof)
+             (< pos (point)))))))
+
+(ert-deftest php-mode-test-issue-503 ()
+  "Function `php-beginning-of-defun' should return non-nil on success."
+  (with-php-mode-test
+   ("issue-503.php")
+   (php-mode)
+   (goto-char (point-max))
+   (should (eq (php-mode-test-in-function-p) nil))
+   (should (eq (php-mode-test-in-function-p (1- (point))) t))
+   (should (eq (php-mode-test-in-function-p 1) nil))
+   (should (eq (php-mode-test-in-function-p 24) t))
+   (goto-char (point-min))
+   (should (eq (php-mode-test-in-function-p nil) nil))))
+
 ;;; php-mode-test.el ends here

--- a/php-mode.el
+++ b/php-mode.el
@@ -786,10 +786,10 @@ but only if the setting is enabled"
   "Move to the beginning of the ARGth PHP function from point.
 Implements PHP version of `beginning-of-defun-function'."
   (interactive "p")
-  (let ((arg (or arg 1)))
+  (let (found-p (arg (or arg 1)))
     (while (> arg 0)
-      (re-search-backward php-beginning-of-defun-regexp
-                          nil 'noerror)
+      (setq found-p (re-search-backward php-beginning-of-defun-regexp
+                                        nil 'noerror))
       (setq arg (1- arg)))
     (while (< arg 0)
       (end-of-line 1)
@@ -798,9 +798,10 @@ Implements PHP version of `beginning-of-defun-function'."
         (forward-list 2)
         (forward-line 1)
         (if (eq opoint (point))
-            (re-search-forward php-beginning-of-defun-regexp
-                               nil 'noerror))
-        (setq arg (1+ arg))))))
+            (setq found-p (re-search-forward php-beginning-of-defun-regexp
+                                             nil 'noerror)))
+        (setq arg (1+ arg))))
+    (not (null found-p))))
 
 (defun php-end-of-defun (&optional arg)
   "Move the end of the ARGth PHP function from point.

--- a/tests/issue-503.php
+++ b/tests/issue-503.php
@@ -1,0 +1,4 @@
+<?php
+function foo () {
+
+}


### PR DESCRIPTION
Closes: #503 

/cc @zonuexe 