### PR TITLE
Enabled to specify suffix of other "facelist" file

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -158,7 +158,8 @@ file name and check that the faces of the fonts in the buffer match."
      ,(if faces
           `(should (equal
                     (php-mode-test--parse-list-file
-                     (concat (expand-file-name ,file php-mode-test-dir) ".faces"))
+                     (concat (expand-file-name ,file php-mode-test-dir)
+                             ,(if (eq t faces) ".faces" faces)))
                     (php-mode-test--buffer-face-list (current-buffer)))))
      (goto-char (point-min))
      (let ((case-fold-search nil))


### PR DESCRIPTION
refs #524

## Example

```diff
diff --git a/php-mode-test.el b/php-mode-test.el
index 98fe95c..0e760be 100644
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -930,7 +930,8 @@ style from Drupal."
 (ert-deftest php-mode-test-issue-443 ()
   "This case allows you to color things that are not authentic PHP tags
 (ex.  `<?xml', `<?hh') as false positives."
-  (with-php-mode-test ("issue-443.php" :faces t)))
+  (with-php-mode-test ("issue-443.php"
+                       :faces (if (version<= "27" emacs-version) ".27.faces" t))))

 (ert-deftest php-mode-test-type-hints ()
   "Test highlighting of type hints and return types."
```

When the condition is met, `issue-443.php` is loaded as "facelist".  `t` is just replaced by `.faces`.