### PR TITLE
Add php-mode-maybe and php-project-php-file-as-template

### DIFF
--- a/php-mode-test.el
+++ b/php-mode-test.el
@@ -271,7 +271,8 @@ an error."
 style from Drupal."
   (dolist (mode '(pear wordpress symfony2))
     ;; the file written to has no significance, only the buffer
-    (let ((tmp-filename (concat (make-temp-name temporary-file-directory) ".php")))
+    (let ((tmp-filename (concat (make-temp-name temporary-file-directory) ".php"))
+          (auto-mode-alist '(("\\.php\\'" . php-mode))))
       (with-php-mode-test ("issue-53.php")
         (search-forward "return $this->bar;")
         (should (equal (list "before-write-file" mode nil)

--- a/php-mode.el
+++ b/php-mode.el
@@ -1600,23 +1600,9 @@ The output will appear in the buffer *PHP*."
 (ad-activate 'fixup-whitespace)
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist
-             (cons
-              (eval-when-compile
-                (rx (or
-                     ;; File name extensions  (ex. "*.php", "*.phtml")
-                     (: "."
-                        (or (: "php" (? (in "s345t")))
-                            "amk"
-                            "phtml"))
-                     ;; Full file names  (ex. "/Makefile", "/Amkfile")
-                     (: "/"
-                        (or "Amkfile"
-                            ".php_cs"
-                            ".php_cs.dist")))
-                    string-end))
-              'php-mode)
-             t)
+(progn
+  (add-to-list 'auto-mode-alist '("\\.\\(?:php[s345]?\\|phtml\\)\\'" . php-mode-maybe))
+  (add-to-list 'auto-mode-alist '("\\.php_cs\\(?:\\.dist\\)?\\'" . php-mode)))
 
 (provide 'php-mode)
 ;;; php-mode.el ends here

--- a/php-mode.el
+++ b/php-mode.el
@@ -1601,8 +1601,8 @@ The output will appear in the buffer *PHP*."
 
 ;;;###autoload
 (progn
-  (add-to-list 'auto-mode-alist '("\\.\\(?:php[s345]?\\|phtml\\)\\'" . php-mode-maybe))
-  (add-to-list 'auto-mode-alist '("\\.php_cs\\(?:\\.dist\\)?\\'" . php-mode)))
+  (add-to-list 'auto-mode-alist '("/\\.php_cs\\(?:\\.dist\\)?\\'" . php-mode))
+  (add-to-list 'auto-mode-alist '("\\.\\(?:php[s345]?\\|phtml\\)\\'" . php-mode-maybe)))
 
 (provide 'php-mode)
 ;;; php-mode.el ends here

--- a/php-project.el
+++ b/php-project.el
@@ -102,79 +102,56 @@ STRING
       If the string is an actual directory path, it is set as the absolute path
       of the root directory, not the marker.")
   (put 'php-project-root 'safe-local-variable
-       #'(lambda (v) (or (stringp v) (assq v php-project-available-root-files)))))
+       #'(lambda (v) (or (stringp v) (assq v php-project-available-root-files))))
 
-;;;###autoload
-(progn
   (defvar-local php-project-bootstrap-scripts nil
     "List of path to bootstrap php script file.
 
 The ideal bootstrap file is silent, it only includes dependent files,
 defines constants, and sets the class loaders.")
-  (put 'php-project-bootstrap-scripts 'safe-local-variable #'php-project--eval-bootstrap-scripts))
+  (put 'php-project-bootstrap-scripts 'safe-local-variable #'php-project--eval-bootstrap-scripts)
 
-;;;###autoload
-(progn
   (defvar-local php-project-php-executable nil
     "Path to php executable file.")
   (put 'php-project-php-executable 'safe-local-variable
-       #'(lambda (v) (and (stringp v) (file-executable-p v)))))
+       #'(lambda (v) (and (stringp v) (file-executable-p v))))
 
-;;;###autoload
-(progn
   (defvar-local php-project-phan-executable nil
     "Path to phan executable file.")
-  (put 'php-project-phan-executable 'safe-local-variable #'php-project--eval-bootstrap-scripts))
+  (put 'php-project-phan-executable 'safe-local-variable #'php-project--eval-bootstrap-scripts)
 
-;;;###autoload
-(progn
   (defvar-local php-project-coding-style nil
     "Symbol value of the coding style of the project that PHP major mode refers to.
 
 Typically it is `pear', `drupal', `wordpress', `symfony2' and `psr2'.")
-  (put 'php-project-coding-style 'safe-local-variable #'symbolp))
+  (put 'php-project-coding-style 'safe-local-variable #'symbolp)
 
-;;;###autoload
-(progn
-  (defvar php-project-repl nil
+  (defvar-local php-project-repl nil
     "Function name or path to REPL (interactive shell) script.")
-  (make-variable-buffer-local 'php-project-repl)
   (put 'php-project-repl 'safe-local-variable
        #'(lambda (v) (or (functionp v)
-                         (php-project--eval-bootstrap-scripts v)))))
+                         (php-project--eval-bootstrap-scripts v))))
 
-;;;###autoload
-(progn
-  (defvar php-project-unit-test nil
+  (defvar-local php-project-unit-test nil
     "Function name or path to unit test script.")
-  (make-variable-buffer-local 'php-project-unit-test)
   (put 'php-project-unit-test 'safe-local-variable
        #'(lambda (v) (or (functionp v)
-                         (php-project--eval-bootstrap-scripts v)))))
+                         (php-project--eval-bootstrap-scripts v))))
 
-;;;###autoload
-(progn
-  (defvar php-project-deploy nil
+  (defvar-local php-project-deploy nil
     "Function name or path to deploy script.")
-  (make-variable-buffer-local 'php-project-deploy)
   (put 'php-project-deploy 'safe-local-variable
        #'(lambda (v) (or (functionp v)
-                         (php-project--eval-bootstrap-scripts v)))))
+                         (php-project--eval-bootstrap-scripts v))))
 
-;;;###autoload
-(progn
-  (defvar php-project-build nil
+  (defvar-local php-project-build nil
     "Function name or path to build script.")
-  (make-variable-buffer-local 'php-project-build)
   (put 'php-project-build 'safe-local-variable
        #'(lambda (v) (or (functionp v)
-                         (php-project--eval-bootstrap-scripts v)))))
+                         (php-project--eval-bootstrap-scripts v))))
 
-;;;###autoload
-(progn
-  (defvar php-project-server-start nil
+  (defvar-local php-project-server-start nil
     "Function name or path to server-start script.")
-  (make-variable-buffer-local 'php-project-server-start)
   (put 'php-project-server-start 'safe-local-variable
        #'(lambda (v) (or (functionp v)
                          (php-project--eval-bootstrap-scripts v)))))

--- a/php-project.el
+++ b/php-project.el
@@ -139,7 +139,7 @@ Typically it is `pear', `drupal', `wordpress', `symfony2' and `psr2'.")
 
 \(\(PATTERN . SYMBOL))
       Alist of file name pattern regular expressions and the above symbol pairs.
-      PATTERN is regexp pattern or `T'.
+      PATTERN is regexp pattern.
 ")
   (put 'php-project-php-file-as-template 'safe-local-variable #'php-project--validate-php-file-as-template)
 
@@ -183,7 +183,7 @@ Typically it is `pear', `drupal', `wordpress', `symfony2' and `psr2'.")
    ((listp val)
     (cl-loop for v in val
              always (and (consp v)
-                         (or (stringp (car v)) (eq t (car v)))
+                         (stringp (car v))
                          (php-project--validate-php-file-as-template (cdr v)))))
    (t nil)))
 

--- a/php.el
+++ b/php.el
@@ -115,6 +115,12 @@ You can replace \"en\" with your ISO language code."
   :type '(alist :key-type regexp :value-type function)
   :link '(url-link :tag "web-mode" "http://web-mode.org/")
   :link '(url-link :tag "phpt-mode" "https://github.com/emacs-php/phpt-mode"))
+
+(defcustom php-mode-maybe-hook nil
+  "List of functions to be executed on entry to `php-mode-maybe'."
+  :group 'php
+  :tag "PHP Mode Maybe Hook"
+  :type 'hook)
 
 ;;; PHP Keywords
 (defconst php-magical-constants
@@ -274,6 +280,7 @@ Look at the `php-executable' variable instead of the constant \"php\" command."
 (defun php-mode-maybe ()
   "Select PHP mode or other major mode."
   (interactive)
+  (run-hooks php-mode-maybe-hook)
   (funcall (php-derivation-major-mode)))
 
 ;;;###autoload

--- a/php.el
+++ b/php.el
@@ -87,7 +87,7 @@ You can replace \"en\" with your ISO language code."
   :type 'string)
 
 (defcustom php-default-major-mode 'php-mode
-  "Major mode for edition PHP script."
+  "Major mode for editing PHP script."
   :group 'php
   :tag "PHP Default Major Mode"
   :type 'function)

--- a/php.el
+++ b/php.el
@@ -85,6 +85,17 @@ You can replace \"en\" with your ISO language code."
   "Suffix for inserted namespace."
   :group 'php
   :type 'string)
+
+(defcustom php-template-mode-alist
+  '(("\\.blade" . web-mode)
+    ("\\.phpt\\'" . phpt-mode)
+    ("\\.phtml\\'" . web-mode))
+  "Automatically use another MAJOR-MODE when open template file."
+  :group 'php
+  :tag "PHP Template Mode Alist"
+  :type '(alist :key-type regexp :value-type function)
+  :link '(url-link :tag "web-mode" "http://web-mode.org/")
+  :link '(url-link :tag "phpt-mode" "https://github.com/emacs-php/phpt-mode"))
 
 ;;; PHP Keywords
 (defconst php-magical-constants
@@ -198,6 +209,19 @@ Look at the `php-executable' variable instead of the constant \"php\" command."
                               'flymake-proc-php-init
                             'flymake-php-init)))))
     (list php-executable (cdr init))))
+
+(eval-when-compile
+  (declare-function php-mode "php-mode"))
+
+;;;###autoload
+(defun php-mode-maybe ()
+  "Select PHP mode or other major mode."
+  (let ((mode (assoc-default buffer-file-name php-template-mode-alist #'string-match-p)))
+    (when (and mode (not (fboundp mode)))
+      (if (string-match-p "\\.blade\\." buffer-file-name)
+          (warn "php-mode is NOT support blade template")
+        (setq mode #'php-mode)))
+    (funcall (or mode #'php-mode))))
 
 ;;;###autoload
 (defun php-current-class ()

--- a/php.el
+++ b/php.el
@@ -86,6 +86,12 @@ You can replace \"en\" with your ISO language code."
   :group 'php
   :type 'string)
 
+(defcustom php-default-major-mode 'php-mode
+  "Major mode for edition PHP script."
+  :group 'php
+  :tag "PHP Default Major Mode"
+  :type 'function)
+
 (defcustom php-template-mode-alist
   '(("\\.blade" . web-mode)
     ("\\.phpt\\'" . phpt-mode)
@@ -210,9 +216,6 @@ Look at the `php-executable' variable instead of the constant \"php\" command."
                             'flymake-php-init)))))
     (list php-executable (cdr init))))
 
-(eval-when-compile
-  (declare-function php-mode "php-mode"))
-
 ;;;###autoload
 (defun php-mode-maybe ()
   "Select PHP mode or other major mode."
@@ -220,8 +223,8 @@ Look at the `php-executable' variable instead of the constant \"php\" command."
     (when (and mode (not (fboundp mode)))
       (if (string-match-p "\\.blade\\." buffer-file-name)
           (warn "php-mode is NOT support blade template")
-        (setq mode #'php-mode)))
-    (funcall (or mode #'php-mode))))
+        (setq mode nil)))
+    (funcall (or mode php-default-major-mode))))
 
 ;;;###autoload
 (defun php-current-class ()

--- a/php.el
+++ b/php.el
@@ -92,10 +92,22 @@ You can replace \"en\" with your ISO language code."
   :tag "PHP Default Major Mode"
   :type 'function)
 
+(defcustom php-html-template-major-mode 'web-mode
+  "Major mode for editing PHP-HTML template."
+  :group 'php
+  :tag "PHP-HTML Template Major Mode"
+  :type 'function)
+
+(defcustom php-blade-template-major-mode 'web-mode
+  "Major mode for editing Blade template."
+  :group 'php
+  :tag "PHP Blade Template Major Mode"
+  :type 'function)
+
 (defcustom php-template-mode-alist
-  '(("\\.blade" . web-mode)
-    ("\\.phpt\\'" . phpt-mode)
-    ("\\.phtml\\'" . web-mode))
+  `(("\\.blade" . ,php-blade-template-major-mode)
+    ("\\.phpt\\'" . ,(if (fboundp 'phpt-mode) 'phpt-mode php-html-template-major-mode))
+    ("\\.phtml\\'" . ,php-html-template-major-mode))
   "Automatically use another MAJOR-MODE when open template file."
   :group 'php
   :tag "PHP Template Mode Alist"

--- a/php.el
+++ b/php.el
@@ -216,6 +216,26 @@ Look at the `php-executable' variable instead of the constant \"php\" command."
                             'flymake-php-init)))))
     (list php-executable (cdr init))))
 
+(defconst php-re-detect-html-tag
+  (eval-when-compile
+    (rx (or (: string-start (* (in space))
+               "<!"
+               (or "DOCTYPE" "doctype")
+               (+ (in space))
+               (or "HTML" "html"))
+            (: (or line-start
+                   (: "<" (? "/")
+                      (* (in space)) (+ (in alpha "-")) (* (in space)) ">"))
+               (: "<" (* (in space)) (+ (in alpha "-")) (* (in space)) ">"))))))
+
+(defun php-buffer-has-html-tag ()
+  "Return position of HTML tag or NIL in current buffer."
+  (save-excursion
+    (save-restriction
+      (widen)
+      (goto-char (point-min))
+      (re-search-forward php-re-detect-html-tag nil t))))
+
 ;;;###autoload
 (defun php-mode-maybe ()
   "Select PHP mode or other major mode."


### PR DESCRIPTION
refs #362 
closes #483 

## Spec of `php-project-php-file-as-template`

This variable is expected to be set by `.dir-locals.el`. You may set the value from the function added to `php-mode-maybe-hook` if it is difficult to set up the [`.dir-locals.el`](https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html) file in your project.

Set this variable to just `t` or `nil` or [association list](https://www.gnu.org/software/emacs/manual/html_node/elisp/Association-Lists.html)(alist).

If your project does not have an HTML template with a .php extension, just set `nil`. Conversely, if every .php file in your project is an HTML template, you should set `t`.

Suppose that your project has a mix of template `.php` files and script `.php` files.  The settings are as follows if the template file has a specific directory or regular extension.

```el
((nil (php-project-root . git)
      (php-project-php-file-as-template
       ("/tpl/" . t) ;; it means the file belongs to `tpl' directory
       ("\\.html\\.php\\'" . t) ;; it means the the file name has `.html.php' extension
       ("\\.php\\'" . nil) ;;it means that if this line is at the end of the list, then all other `.php' files are not template.
       )))
```

If you are not used to editing `.dir-locals.el`, be careful not to break the balance of `()`.
Read [Per-Directory Local Variables](https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html) of Emacs manual carefully for an explanation of the `.dir-locals.el` file.

An example of setting this variable to t or nil is as follows: (Don't forget `.`)

```el
((nil (php-project-root . git)
      (php-project-php-file-as-template . t)))
```

**Note**: According to the Lisp specification, `(A. (X Y Z))` and `(A X Y Z)` have exactly the same meaning.
