### PR TITLE
Support poly-php-html-mode

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -820,12 +820,17 @@ example `html-mode'.  Known such libraries are:\n\t"
         nil))))
 
 (defun php-cautious-indent-region (start end &optional quiet)
+  "Carefully indent region `START' `END' in contexts other than HTML templates.
+
+If the optional argument `QUIET' is non-nil then no syntactic errors are
+reported, even if `c-report-syntactic-errors' is non-nil."
   (if (or (not php-mode-warn-if-mumamo-off)
           php-warned-bad-indent
           (php-check-html-for-indentation))
       (funcall 'c-indent-region start end quiet)))
 
 (defun php-cautious-indent-line ()
+  "Carefully indent lines in contexts other than HTML templates."
   (if (or (not php-mode-warn-if-mumamo-off)
           php-warned-bad-indent
           (php-check-html-for-indentation))

--- a/php-mode.el
+++ b/php-mode.el
@@ -825,6 +825,7 @@ example `html-mode'.  Known such libraries are:\n\t"
 If the optional argument `QUIET' is non-nil then no syntactic errors are
 reported, even if `c-report-syntactic-errors' is non-nil."
   (if (or (not php-mode-warn-if-mumamo-off)
+          (not (php-in-poly-php-html-mode))
           php-warned-bad-indent
           (php-check-html-for-indentation))
       (funcall 'c-indent-region start end quiet)))
@@ -832,6 +833,7 @@ reported, even if `c-report-syntactic-errors' is non-nil."
 (defun php-cautious-indent-line ()
   "Carefully indent lines in contexts other than HTML templates."
   (if (or (not php-mode-warn-if-mumamo-off)
+          (not (php-in-poly-php-html-mode))
           php-warned-bad-indent
           (php-check-html-for-indentation))
       (let ((here (point))

--- a/php.el
+++ b/php.el
@@ -108,6 +108,11 @@ it is the character that will terminate the string, or t if the string should be
   "Return character address of start of comment or string; nil if not in one."
   (nth 8 (syntax-ppss)))
 
+(defsubst php-in-poly-php-html-mode ()
+  "Return T if current buffer is in `poly-html-mode'."
+  (and (boundp 'poly-php-html-mode)
+       (symbol-value 'poly-php-html-mode)))
+
 (defun php-create-regexp-for-method (visibility)
   "Make a regular expression for methods with the given VISIBILITY.
 


### PR DESCRIPTION
refs #538

Suppress warnings when editing from `poly-php-html-mode`.