### PR TITLE
Move php-mode-test.el into tests directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 EMACS ?= emacs
-ELS = php.el php-face.el php-project.el php-mode.el php-mode-debug.el php-mode-test.el
+ELS = php.el php-face.el php-project.el php-mode.el php-mode-debug.el
 AUTOLOADS = php-mode-autoloads.el
 ELCS = $(ELS:.el=.elc)
 
@@ -37,6 +37,6 @@ dev:
 # for an example of using a script like this with the 'git bisect run'
 # command.
 test: clean all
-	$(EMACS) -Q -batch -L . -l php-mode-test.el -f ert-run-tests-batch-and-exit
+	$(EMACS) -Q -batch -L . -l tests/php-mode-test.el -f ert-run-tests-batch-and-exit
 
 .PHONY: all autoloads clean test

--- a/tests/php-mode-test.el
+++ b/tests/php-mode-test.el
@@ -42,10 +42,9 @@
 ;; <http://debbugs.gnu.org/cgi/bugreport.cgi?bug=14325>.
 (c-after-font-lock-init)
 
-(defvar php-mode-test-dir (expand-file-name "tests"
-                                         (if load-file-name
-                                             (file-name-directory load-file-name)
-                                           default-directory))
+(defvar php-mode-test-dir (if load-file-name
+                           (file-name-directory load-file-name)
+                         default-directory)
   "Directory containing the `php-mode' test files.")
 
 (defvar php-mode-test-valid-magics '(indent)


### PR DESCRIPTION
With this change, the autoloads file no longer contains `php-mode-test.el` information.