### PR TITLE
Modify syntax-entry $ to "_" from "'"

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1073,7 +1073,7 @@ After setting the stylevars run hooks according to STYLENAME
     (modify-syntax-entry ?\" "\""  table)
     (modify-syntax-entry ?#  "< b" table)
     (modify-syntax-entry ?\n "> b" table)
-    (modify-syntax-entry ?$  "'"   table)
+    (modify-syntax-entry ?$  "_"   table)
     table))
 
 ;;;###autoload


### PR DESCRIPTION
In practice, `$` is just part of the variable name, which is more advantageous than considering it as “Expression prefixes”.

If you want to be compatible with older syntax tables, add the following code to your own .emacs file (`init.el`):

```el
(with-eval-after-load "php-mode"
  (modify-syntax-entry ?$  "'"   php-mode-syntax-table))
```

Past discussions are in the following issues:

 * https://github.com/emacs-php/php-mode/issues/320
 * https://github.com/emacs-php/php-mode/issues/564