### PR TITLE
Add php-project-etags-file and php-project-apply-local-variables

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -342,6 +342,12 @@ In that case set to `NIL'."
   :tag "PHP Mode Disable C Mode Hook"
   :type 'boolean)
 
+(defcustom php-mode-enable-project-local-variable t
+  "When set to `T', apply project local variable to buffer local variable."
+  :group 'php-mode
+  :tag "PHP Mode Enable Project Local Variable"
+  :type 'boolean)
+
 (defun php-mode-version ()
   "Display string describing the version of PHP Mode."
   (interactive)
@@ -1116,6 +1122,11 @@ After setting the stylevars run hooks according to STYLENAME
                (php-set-style (symbol-name coding-style)))
         (remove-hook 'hack-local-variables-hook #'php-mode-set-style-delay)))))
 
+(defun php-mode-set-local-variable-delay ()
+  "Set local variable from php-project."
+  (php-project-apply-local-variables)
+  (remove-hook 'hack-local-variables-hook #'php-mode-set-local-variable-delay))
+
 (defvar php-mode-syntax-table
   (let ((table (make-syntax-table)))
     (c-populate-syntax-table table)
@@ -1168,6 +1179,9 @@ After setting the stylevars run hooks according to STYLENAME
 
   ;; PHP vars are case-sensitive
   (setq case-fold-search t)
+
+  (when php-mode-enable-project-local-variable
+    (add-hook 'hack-local-variables-hook #'php-mode-set-local-variable-delay t t))
 
   ;; When php-mode-enable-project-coding-style is set, it is delayed by hook.
   ;; Since it depends on the timing at which the file local variable is set.

--- a/php-project.el
+++ b/php-project.el
@@ -104,6 +104,11 @@ STRING
   (put 'php-project-root 'safe-local-variable
        #'(lambda (v) (or (stringp v) (assq v php-project-available-root-files))))
 
+  (defvar-local php-project-etags-file nil)
+  (put 'php-project-etags-file 'safe-local-variable
+       #'(lambda (v) (or (functionp v)
+                         (php-project--eval-bootstrap-scripts v))))
+
   (defvar-local php-project-bootstrap-scripts nil
     "List of path to bootstrap php script file.
 
@@ -172,7 +177,6 @@ Typically it is `pear', `drupal', `wordpress', `symfony2' and `psr2'.")
   (put 'php-project-server-start 'safe-local-variable
        #'(lambda (v) (or (functionp v)
                          (php-project--eval-bootstrap-scripts v)))))
-
 
 ;; Functions
 (defun php-project--validate-php-file-as-template (val)

--- a/php-project.el
+++ b/php-project.el
@@ -233,6 +233,11 @@ Typically it is `pear', `drupal', `wordpress', `symfony2' and `psr2'.")
    (t (prog1 nil
         (warn "php-project-php-file-as-template is unexpected format")))))
 
+(defun php-project-apply-local-variables ()
+  "Apply php-project variables to local variables."
+  (when (and php-project-etags-file (null tags-file-name))
+    (setq-local tags-file-name (php-project--eval-bootstrap-scripts php-project-etags-file))))
+
 ;;;###autoload
 (defun php-project-get-bootstrap-scripts ()
   "Return list of bootstrap script."


### PR DESCRIPTION
## Motivation

If you are developing multiple projects on a daily basis, managing `TAGS` files is cumbersome. This system realizes the application of TAGS files automatically by per project setting (`.dir-locals.el`) or automatic detection mechanism.

## How to use

The following `.dir-locals.el` code sets the `TAGS` file for each project.

```el
((nil (php-project-root . git)
      (php-project-etags-file . (root . "TAGS")))
```

or 

```el
((nil (php-project-root . git)
      (php-project-etags-file . t))
```

## Apply automatic settings without a configuration file

```el
(custom-set-variables
 '(php-project-auto-detect-etags-file tl))
```

## How to disable this mechanism

```el
(custom-set-variables
 '(php-mode-enable-project-local-variable nil))
```
