### PR TITLE
Add individual faces

### DIFF
--- a/php-face.el
+++ b/php-face.el
@@ -281,6 +281,11 @@
   :group 'php-faces
   :tag "PHP Constant Keywords")
 
+(defface php-number '((t (:inherit default)))
+  "Face used to highlight numbers."
+  :group 'php-faces
+  :tag "PHP Numbers")
+
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 (provide 'php-face)

--- a/php-face.el
+++ b/php-face.el
@@ -286,6 +286,11 @@
   :group 'php-faces
   :tag "PHP Numbers")
 
+(defface php-string-quote '((t (:inherit php-string)))
+  "Face used to highlight quotes surrounding a string."
+  :group 'php-faces
+  :tag "PHP String Quotes")
+
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 (provide 'php-face)

--- a/php-face.el
+++ b/php-face.el
@@ -202,9 +202,14 @@
   :tag "PHPDoc Class Name")
 
 (defface php-class-declaration '((t (:inherit php-keyword)))
-  "Face used to class declarations."
+  "Face used to highlight class declaration keywords"
   :group 'php-faces
   :tag "PHP Class Declaration")
+
+(defface php-class-declaration-spec '((t (:inherit php-keyword)))
+  "Face used to highlight class declaration specification keywords (implements, extends)"
+  :group 'php-faces
+  :tag "PHP Class Declaration Specification")
 
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 

--- a/php-face.el
+++ b/php-face.el
@@ -216,6 +216,12 @@
   :group 'php-faces
   :tag "PHP Namespace Declaration")
 
+
+(defface php-import-declaration '((t (:inherit php-keyword)))
+  "Face used to highlight import statements (use ... as ...)"
+  :group 'php-faces
+  :tag "PHP Import Statement")
+
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 (provide 'php-face)

--- a/php-face.el
+++ b/php-face.el
@@ -201,6 +201,11 @@
   :group 'php-faces
   :tag "PHPDoc Class Name")
 
+(defface php-class-declaration '((t (:inherit font-lock-keyword-face)))
+  "Face used to class declarations."
+  :group 'php-faces
+  :tag "PHP Class Declaration")
+
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 (provide 'php-face)

--- a/php-face.el
+++ b/php-face.el
@@ -226,6 +226,11 @@
   :group 'php-faces
   :tag "PHP Class Modifiers")
 
+(defface php-modifiers-method '((t (:inherit php-keyword)))
+  "Face used to highlight method modifiers (final, abstract)"
+  :group 'php-faces
+  :tag "PHP Method Modifiers")
+
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 (provide 'php-face)

--- a/php-face.el
+++ b/php-face.el
@@ -117,7 +117,7 @@
   :tag "PHP Increment/Decrement Op")
 
 (defface php-string-op '((t (:inherit php-operator)))
-  "PHP Mode face used to logical operators (.)."
+  "PHP Mode face used to string operator (.)."
   :group 'php-faces
   :tag "PHP String Op")
 
@@ -290,6 +290,11 @@
   "Face used to highlight quotes surrounding a string."
   :group 'php-faces
   :tag "PHP String Quotes")
+
+(defface php-block-delimiter '((t (:inherit default)))
+  "Face used to highlight block delimiters ((, ), [, ], {, })"
+  :group 'php-faces
+  :tag "PHP Block Delimiters")
 
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 

--- a/php-face.el
+++ b/php-face.el
@@ -256,6 +256,11 @@
   :group 'php-faces
   :tag "PHP Property Static")
 
+(defface php-block-statement '((t (:inherit php-keyword)))
+  "Face used to highlight block statements (if, elseif, for, foreach, while, declare, switch, catch)."
+  :group 'php-faces
+  :tag "PHP Block Statement")
+
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 (provide 'php-face)

--- a/php-face.el
+++ b/php-face.el
@@ -301,11 +301,15 @@
   :group 'php-faces
   :tag "PHP Type Op")
 
-
 (defface php-return-type-colon '((t (:inherit default)))
   "Face used to highlight : character in front of return type."
   :group 'php-faces
   :tag "PHP Return Type Colon")
+
+(defface php-function-keyword '((t (:inherit php-keyword)))
+  "Face used to highlight the 'function' keyword in declaration."
+  :group 'php-faces
+  :tag "PHP Function Keyword")
 
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 

--- a/php-face.el
+++ b/php-face.el
@@ -219,17 +219,17 @@
 (defface php-import-declaration '((t (:inherit php-keyword)))
   "Face used to highlight import statements (use ... as ...)."
   :group 'php-faces
-  :tag "PHP Import Statement")
+  :tag "PHP Import Declaration")
 
-(defface php-class-modifiers '((t (:inherit php-keyword)))
+(defface php-class-modifier '((t (:inherit php-keyword)))
   "Face used to highlight class modifiers (final, abstract)."
   :group 'php-faces
-  :tag "PHP Class Modifiers")
+  :tag "PHP Class Modifier")
 
-(defface php-method-modifiers '((t (:inherit php-keyword)))
+(defface php-method-modifier '((t (:inherit php-keyword)))
   "Face used to highlight method modifiers (final, abstract)."
   :group 'php-faces
-  :tag "PHP Method Modifiers")
+  :tag "PHP Method Modifier")
 
 (defface php-method-access '((t (:inherit php-keyword)))
   "Face used to highlight method access keywords (public, protected, private)."
@@ -279,27 +279,27 @@
 (defface php-constant-keyword '((t (:inherit php-keyword)))
   "Face used to highlight constant keywords (true, false, null)."
   :group 'php-faces
-  :tag "PHP Constant Keywords")
+  :tag "PHP Constant Keyword")
 
 (defface php-number '((t (:inherit default)))
   "Face used to highlight numbers."
   :group 'php-faces
-  :tag "PHP Numbers")
+  :tag "PHP Number")
 
 (defface php-string-quote '((t (:inherit php-string)))
   "Face used to highlight quotes surrounding a string."
   :group 'php-faces
-  :tag "PHP String Quotes")
+  :tag "PHP String Quote")
 
 (defface php-block-delimiter '((t (:inherit default)))
   "Face used to highlight block delimiters ((, ), [, ], {, })"
   :group 'php-faces
-  :tag "PHP Block Delimiters")
+  :tag "PHP Block Delimiter")
 
 (defface php-type-operator '((t (:inherit default)))
   "Face used to highlight type operators (insteadof, instanceof)"
   :group 'php-faces
-  :tag "PHP Type Operators")
+  :tag "PHP Type Op")
 
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 

--- a/php-face.el
+++ b/php-face.el
@@ -221,15 +221,20 @@
   :group 'php-faces
   :tag "PHP Import Statement")
 
-(defface php-modifiers-class '((t (:inherit php-keyword)))
+(defface php-class-modifiers '((t (:inherit php-keyword)))
   "Face used to highlight class modifiers (final, abstract)"
   :group 'php-faces
   :tag "PHP Class Modifiers")
 
-(defface php-modifiers-method '((t (:inherit php-keyword)))
+(defface php-method-modifiers '((t (:inherit php-keyword)))
   "Face used to highlight method modifiers (final, abstract)"
   :group 'php-faces
   :tag "PHP Method Modifiers")
+
+(defface php-property-access '((t (:inherit php-keyword)))
+  "Face used to highlight property access keywords (public, protected, public)"
+  :group 'php-faces
+  :tag "PHP Property Access")
 
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 

--- a/php-face.el
+++ b/php-face.el
@@ -296,6 +296,11 @@
   :group 'php-faces
   :tag "PHP Block Delimiters")
 
+(defface php-type-operator '((t (:inherit default)))
+  "Face used to highlight type operators (insteadof, instanceof)"
+  :group 'php-faces
+  :tag "PHP Type Operators")
+
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 (provide 'php-face)

--- a/php-face.el
+++ b/php-face.el
@@ -276,6 +276,11 @@
   :group 'php-faces
   :tag "PHP Include Statement")
 
+(defface php-constant-keyword '((t (:inherit php-keyword)))
+  "Face used to highlight constant keywords (true, false, null)."
+  :group 'php-faces
+  :tag "PHP Constant Keywords")
+
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 (provide 'php-face)

--- a/php-face.el
+++ b/php-face.el
@@ -211,6 +211,11 @@
   :group 'php-faces
   :tag "PHP Class Declaration Specification")
 
+(defface php-namespace-declaration '((t (:inherit php-keyword)))
+  "Face used to highlight namespace declaration keyword."
+  :group 'php-faces
+  :tag "PHP Namespace Declaration")
+
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 (provide 'php-face)

--- a/php-face.el
+++ b/php-face.el
@@ -201,7 +201,7 @@
   :group 'php-faces
   :tag "PHPDoc Class Name")
 
-(defface php-class-declaration '((t (:inherit font-lock-keyword-face)))
+(defface php-class-declaration '((t (:inherit php-keyword)))
   "Face used to class declarations."
   :group 'php-faces
   :tag "PHP Class Declaration")

--- a/php-face.el
+++ b/php-face.el
@@ -216,11 +216,15 @@
   :group 'php-faces
   :tag "PHP Namespace Declaration")
 
-
 (defface php-import-declaration '((t (:inherit php-keyword)))
   "Face used to highlight import statements (use ... as ...)"
   :group 'php-faces
   :tag "PHP Import Statement")
+
+(defface php-modifiers-class '((t (:inherit php-keyword)))
+  "Face used to highlight class modifiers (final, abstract)"
+  :group 'php-faces
+  :tag "PHP Class Modifiers")
 
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 

--- a/php-face.el
+++ b/php-face.el
@@ -202,12 +202,12 @@
   :tag "PHPDoc Class Name")
 
 (defface php-class-declaration '((t (:inherit php-keyword)))
-  "Face used to highlight class declaration keywords"
+  "Face used to highlight class declaration keywords."
   :group 'php-faces
   :tag "PHP Class Declaration")
 
 (defface php-class-declaration-spec '((t (:inherit php-keyword)))
-  "Face used to highlight class declaration specification keywords (implements, extends)"
+  "Face used to highlight class declaration specification keywords (implements, extends)."
   :group 'php-faces
   :tag "PHP Class Declaration Specification")
 
@@ -217,22 +217,32 @@
   :tag "PHP Namespace Declaration")
 
 (defface php-import-declaration '((t (:inherit php-keyword)))
-  "Face used to highlight import statements (use ... as ...)"
+  "Face used to highlight import statements (use ... as ...)."
   :group 'php-faces
   :tag "PHP Import Statement")
 
 (defface php-class-modifiers '((t (:inherit php-keyword)))
-  "Face used to highlight class modifiers (final, abstract)"
+  "Face used to highlight class modifiers (final, abstract)."
   :group 'php-faces
   :tag "PHP Class Modifiers")
 
 (defface php-method-modifiers '((t (:inherit php-keyword)))
-  "Face used to highlight method modifiers (final, abstract)"
+  "Face used to highlight method modifiers (final, abstract)."
   :group 'php-faces
   :tag "PHP Method Modifiers")
 
+(defface php-method-access '((t (:inherit php-keyword)))
+  "Face used to highlight method access keywords (public, protected, private)."
+  :group 'php-faces
+  :tag "PHP Method Access")
+
+(defface php-method-static '((t (:inherit php-keyword)))
+  "Face used to highlight static keyword in method declaration."
+  :group 'php-faces
+  :tag "PHP Method Static")
+
 (defface php-property-access '((t (:inherit php-keyword)))
-  "Face used to highlight property access keywords (public, protected, public)"
+  "Face used to highlight property access keywords (public, protected, private)."
   :group 'php-faces
   :tag "PHP Property Access")
 

--- a/php-face.el
+++ b/php-face.el
@@ -261,6 +261,21 @@
   :group 'php-faces
   :tag "PHP Block Statement")
 
+(defface php-flow-control-statement '((t (:inherit php-keyword)))
+  "Face used to highlight flow control statements (break, continue, die, exit, goto, return, throw)."
+  :group 'php-faces
+  :tag "PHP Flow Control Statement")
+
+(defface php-print-statement '((t (:inherit php-keyword)))
+  "Face used to highlight print statements (echo, print, var_dump)."
+  :group 'php-faces
+  :tag "PHP Print Statement")
+
+(defface php-include-statement '((t (:inherit php-keyword)))
+  "Face used to highlight include statements (include, include_once, require, require_once)."
+  :group 'php-faces
+  :tag "PHP Include Statement")
+
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 (provide 'php-face)

--- a/php-face.el
+++ b/php-face.el
@@ -301,6 +301,12 @@
   :group 'php-faces
   :tag "PHP Type Op")
 
+
+(defface php-return-type-colon '((t (:inherit default)))
+  "Face used to highlight : character in front of return type."
+  :group 'php-faces
+  :tag "PHP Return Type Colon")
+
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 (provide 'php-face)

--- a/php-face.el
+++ b/php-face.el
@@ -246,6 +246,16 @@
   :group 'php-faces
   :tag "PHP Property Access")
 
+(defface php-property-const '((t (:inherit php-keyword)))
+  "Face used to highlight const keyword in property declaration."
+  :group 'php-faces
+  :tag "PHP Property Const")
+
+(defface php-property-static '((t (:inherit php-keyword)))
+  "Face used to highlight static keyword in property declaration."
+  :group 'php-faces
+  :tag "PHP Property Static")
+
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")
 
 (provide 'php-face)

--- a/php-mode.el
+++ b/php-mode.el
@@ -1575,6 +1575,15 @@ a completion list."
 
      ;; Block statements (if, elseif, for, foreach, catch, switch, while, declare)
      ("if\\|elseif\\|for\\|foreach\\|catch\\|switch\\|while\\|declare" . 'php-block-statement)
+
+     ;; Flow control statements (break, continue, die, exit, goto, return, throw)
+     ("break\\|continue\\|die\\|exit\\|goto\\|return\\|throw" . 'php-flow-control-statement)
+
+     ;; Print statements (echo, print, var_dump)
+     ("echo\\|print\\|var_dump" . 'php-print-statement)
+
+     ;; Include statements (include, include_once, require, require_once)
+     ("include[^_]\\|include_once\\|require[^_]\\|require_once" . 'php-include-statement)
      
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()

--- a/php-mode.el
+++ b/php-mode.el
@@ -1541,6 +1541,9 @@ a completion list."
    `(
      ;; Class declaration keywords (class, trait, interface)
      ("class\\|trait\\|interface" . 'php-class-declaration)
+
+     ;; Class declaration specification keywords (implements, extends)
+     ("implements\\|extends" . 'php-class-declaration-spec)
      
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()

--- a/php-mode.el
+++ b/php-mode.el
@@ -1587,7 +1587,7 @@ a completion list."
 
      ;; Constant keywords
      ("true\\|false\\|null" . 'php-constant-keyword)
-     
+
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()
      ("\\(->\\)\\(\\sw+\\)\\s-*(" (1 'php-object-op) (2 'php-method-call))
@@ -1720,7 +1720,10 @@ a completion list."
 
      ;; Logical operators (and, or, &&, ...)
      ;; Not operator (!) is defined in "before cc-mode" section above.
-     ("\\(&&\\|||\\)" 1 'php-logical-op)))
+     ("\\(&&\\|||\\)" 1 'php-logical-op)
+     
+     ;; Numbers
+     ("[0-9]+\\.?" . 'php-number)))
   "Detailed highlighting for PHP Mode.")
 
 (defvar php-font-lock-keywords php-font-lock-keywords-3

--- a/php-mode.el
+++ b/php-mode.el
@@ -1540,7 +1540,7 @@ a completion list."
    ;;  a different face.
    `(
      ;; Class declaration keywords (class, trait, interface)
-     ("class\\|trait\\|interface" . 'php-class-declaration)
+     ("\\(class\\|trait\\|interface\\)[^(]" (1 'php-class-declaration))
 
      ;; Class declaration specification keywords (implements, extends)
      ("implements\\|extends" . 'php-class-declaration-spec)

--- a/php-mode.el
+++ b/php-mode.el
@@ -1556,16 +1556,23 @@ a completion list."
      ("\\(abstract\\|final\\)[[:space:]]\\(?:class\\)" (1 'php-class-modifiers))
 
      ;; Method modifiers (abstract, final)
-     ("\\(abstract\\|final\\)[[:space:]]\\(?:static\\|public\\|private\\|protected\\|function\\)" (1 'php-method-modifiers))
+     ("\\(abstract\\|final\\)\\(?:[[:space:]]static\\|[[:space:]]public\\|[[:space:]]private\\|[[:space:]]protected\\)*\\(?:[[:space:]]function\\)" (1 'php-method-modifiers))
 
      ;; Method access protection (public, protected, private)
-     ("\\(private\\|protected\\|public\\)[[:space:]]\\(?:static\\|function\\|abstract|\\final\\)" (1 'php-method-access))
+     ("\\(private\\|protected\\|public\\)\\(?:[[:space:]]static\\|[[:space:]]final\\|[[:space:]]abstract\\)*\\(?:[[:space:]]function\\)" (1 'php-method-access))
 
      ;; Method static modifier
-     ("\\(static\\)[[:space:]]\\(?:public\\|protected\\|private\\|function\\|abstract\\|final\\)" (1 'php-method-static))
+     ("\\(static\\)\\(?:[[:space:]]private\\|[[:space:]]protected\\|[[:space:]]public\\|[[:space:]]final\\|[[:space:]]abstract\\)*\\(?:[[:space:]]function\\)" (1 'php-method-static))
+
+     ;; Property constants
+     ("\\(const\\)[[:space:]]\\(?:[^\$][[:word:]]\\)" (1 'php-property-const))
      
      ;; Property access protection
-     ;("\\(private\\|protected\\|public\\)\\(?:[[:space:]]const[[:space:]][[:word:]]\\|[[:space:]]\$[[:word:]]\\)" (1 'php-property-access))
+     ("\\(private\\|protected\\|public\\)\\(?:[[:space:]]static\\|[[:space:]]const\\)?\\(?:[[:space:]]\$?[[:word:]]+\\)\\(?:[[:space:]]*=[[:space:]]*[^;]+\\)?\\(?:;\\)" (1 'php-property-access))
+     ;("\\(private\\|protected\\|public\\)[[:space:]]\\(?:const[[:space:]][^\$][[:word:]]\\|\$[[:word:]]\\)" (1 'php-property-access))
+
+     ;; Property static modifier
+     ;;("\\(static\\)[[:space:]]\\(?:public\\|protected\\|private\\)" (1 'php-property-static))
      
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()

--- a/php-mode.el
+++ b/php-mode.el
@@ -1564,6 +1564,9 @@ a completion list."
      ;; Method static modifier
      ("\\(static\\)\\(?:[[:space:]]private\\|[[:space:]]protected\\|[[:space:]]public\\|[[:space:]]final\\|[[:space:]]abstract\\)*\\(?:[[:space:]]function\\)" (1 'php-method-static))
 
+     ;; function keyword
+     ("\\(function\\)\\(?:[[:space:]]+[_[:word:]\\]+[[:space:]]*(\\)" (1 'php-function-keyword))
+     
      ;; Property constants
      ("\\(const\\)[[:space:]]\\(?:[^\$][[:word:]]\\)" (1 'php-property-const))
      

--- a/php-mode.el
+++ b/php-mode.el
@@ -1551,6 +1551,9 @@ a completion list."
      ;; import statement (use ... as ...)
      ("\\(use[[:space:]]\\)\\(?:[[:word:]\\]\\)" (1 'php-import-declaration))
      ("\\(?:[[:word:]\\]\\)\\([[:space:]]as\\)" (1 'php-import-declaration))
+
+     ;; Class modifiers (abstract, final)
+     ("\\(abstract\\|final\\)[[:space:]]\\(?:class\\)" (1 'php-modifiers-class))
      
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()

--- a/php-mode.el
+++ b/php-mode.el
@@ -1729,7 +1729,7 @@ a completion list."
      ("\\(?:[^0-9[:space:]]\\)\\([[:space:]]*\\.[[:space:]]*\\)\\(?:[^0-9[:space:]]\\)" . (1 'php-string-op))
      
      ;; Block delimiters ((, ), [, ], {, })
-     ("\(\\|\)\\|\[\\|\]\\|\{\\|\}" . 'php-block-delimiter)
+     ("\(\\|\)\\|\\[\\|\\]\\|\{\\|\}" . 'php-block-delimiter)
 
      ;; Numbers
      ("[0-9]+\\.?" . 'php-number)))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1553,10 +1553,10 @@ a completion list."
      ("\\(?:[[:word:]\\]\\)\\([[:space:]]as\\)" (1 'php-import-declaration))
 
      ;; Class modifiers (abstract, final)
-     ("\\(abstract\\|final\\)[[:space:]]\\(?:class\\)" (1 'php-class-modifiers))
+     ("\\(abstract\\|final\\)[[:space:]]\\(?:class\\)" (1 'php-class-modifier))
 
      ;; Method modifiers (abstract, final)
-     ("\\(abstract\\|final\\)\\(?:[[:space:]]static\\|[[:space:]]public\\|[[:space:]]private\\|[[:space:]]protected\\)*\\(?:[[:space:]]function\\)" (1 'php-method-modifiers))
+     ("\\(abstract\\|final\\)\\(?:[[:space:]]static\\|[[:space:]]public\\|[[:space:]]private\\|[[:space:]]protected\\)*\\(?:[[:space:]]function\\)" (1 'php-method-modifier))
 
      ;; Method access protection (public, protected, private)
      ("\\(private\\|protected\\|public\\)\\(?:[[:space:]]static\\|[[:space:]]final\\|[[:space:]]abstract\\)*\\(?:[[:space:]]function\\)" (1 'php-method-access))

--- a/php-mode.el
+++ b/php-mode.el
@@ -688,6 +688,7 @@ but only if the setting is enabled"
                        (case-label . +)
                        (class-open . 0)
                        (comment-intro . 0)
+                       (inexpr-class . 0)
                        (inlambda . 0)
                        (inline-open . 0)
                        (namespace-open . 0)
@@ -1550,7 +1551,7 @@ a completion list."
      ("\\(\\$\\)\\(this\\)\\>" (1 'php-$this-sigil) (2 'php-$this))
      ("\\(\\$+\\)\\(\\sw+\\)" (1 'php-variable-sigil) (2 'php-variable-name))
      ("\\(->\\)\\([a-zA-Z0-9_]+\\)" (1 'php-object-op) (2 'php-property-name))
-     
+
      ;; Highlight function/method names
      ("\\<function\\s-+&?\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*(" 1 'php-function-name)
 
@@ -1625,7 +1626,7 @@ a completion list."
 
      ;; Highlight class name after "use .. as"
      ("\\<as\\s-+\\(\\sw+\\)" 1 font-lock-type-face)
-     
+
      ;; Class names are highlighted by cc-mode as defined in
      ;; c-class-decl-kwds, below regexp is a workaround for a bug
      ;; where the class names are not highlighted right after opening
@@ -1656,7 +1657,7 @@ a completion list."
      (")\\s-*:\\s-*\\??\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*\\(?:\{\\|;\\)" 1 font-lock-type-face)
 
      ;; Assignment operators (=, +=, ...)
-     ("\\([^=<!>]+?\\([\-+./%]?=\\)[^=<!>]+?\\)" 2 'php-assignment-op)
+     ("\\([^=<!>]+?\\([\-+./%]?=\\)[^=<!]+?\\)" 2 'php-assignment-op)
 
      ;; Comparison operators (==, ===, >=, ...)
      ("\\([!=]=\\{1,2\\}[>]?\\|[<>]=?\\)" 1 'php-comparison-op)
@@ -1670,8 +1671,7 @@ a completion list."
 
      ;; Logical operators (and, or, &&, ...)
      ;; Not operator (!) is defined in "before cc-mode" section above.
-     ("\\(&&\\|\|\|\\)" 1 'php-logical-op)
-     ))
+     ("\\(&&\\|||\\)" 1 'php-logical-op)))
   "Detailed highlighting for PHP Mode.")
 
 (defvar php-font-lock-keywords php-font-lock-keywords-3

--- a/php-mode.el
+++ b/php-mode.el
@@ -1721,7 +1721,7 @@ a completion list."
      ;; Logical operators (and, or, &&, ...)
      ;; Not operator (!) is defined in "before cc-mode" section above.
      ("\\(&&\\|||\\)" 1 'php-logical-op)
-     
+
      ;; Numbers
      ("[0-9]+\\.?" . 'php-number)))
   "Detailed highlighting for PHP Mode.")
@@ -1767,7 +1767,8 @@ The output will appear in the buffer *PHP*."
   '(progn
      (font-lock-add-keywords
       'php-mode
-      `((php-string-intepolated-variable-font-lock-find))
+      `((php-string-intepolated-variable-font-lock-find)
+	("\\s\"\\|\\s|" 0 'php-string-quote t))
       'append)))
 
 

--- a/php-mode.el
+++ b/php-mode.el
@@ -1556,13 +1556,13 @@ a completion list."
      ("\\(abstract\\|final\\)[[:space:]]\\(?:class\\)" (1 'php-class-modifiers))
 
      ;; Method modifiers (abstract, final)
-     ("\\(abstract\\|final\\)[[:space:]]\\(?:static\\|public\\|private\\|protected\\)" (1 'php-method-modifiers))
+     ("\\(abstract\\|final\\)[[:space:]]\\(?:static\\|public\\|private\\|protected\\|function\\)" (1 'php-method-modifiers))
 
-     ;; Method access protection
-     ("\\(private\\|protected\\|public\\)[[:space:]]\\(?:static\\|function\\)" (1 'php-method-access))
+     ;; Method access protection (public, protected, private)
+     ("\\(private\\|protected\\|public\\)[[:space:]]\\(?:static\\|function\\|abstract|\\final\\)" (1 'php-method-access))
 
      ;; Method static modifier
-     ("\\(static\\)[[:space:]]\\(?:public\\|protected\\|private\\|function\\)" (1 'php-method-static))
+     ("\\(static\\)[[:space:]]\\(?:public\\|protected\\|private\\|function\\|abstract\\|final\\)" (1 'php-method-static))
      
      ;; Property access protection
      ;("\\(private\\|protected\\|public\\)\\(?:[[:space:]]const[[:space:]][[:word:]]\\|[[:space:]]\$[[:word:]]\\)" (1 'php-property-access))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1,4 +1,4 @@
-;;; php-mode.el --- Major mode for editing PHP code
+3;;; php-mode.el --- Major mode for editing PHP code
 
 ;; Copyright (C) 2018-2019  Friends of Emacs-PHP development
 ;; Copyright (C) 1999, 2000, 2001, 2003, 2004 Turadg Aleahmad
@@ -1544,6 +1544,9 @@ a completion list."
 
      ;; Class declaration specification keywords (implements, extends)
      ("implements\\|extends" . 'php-class-declaration-spec)
+
+     ;; Namespace declaration
+     ("namespace" .  'php-namespace-declaration)
      
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()

--- a/php-mode.el
+++ b/php-mode.el
@@ -1572,7 +1572,10 @@ a completion list."
 
      ;; Property static modifier
      ("\\(static\\)\\(?:[[:space:]]private\\|[[:space:]]protected\\|[[:space:]]public\\)?\\(?:[[:space:]]\$?[[:word:]]+\\)\\(?:[[:space:]]*=[[:space:]]*[^;]+\\)?\\(?:;\\)" (1 'php-property-static))
-  
+
+     ;; Block statements (if, elseif, for, foreach, catch, switch, while, declare)
+     ("\\(if\\|elseif\\|for\\|foreach\\|catch\\|switch\\|while\\|declare\\)\\(?:[[:space:]]*\([[:space:]]*.*[[:space:]]*\)\\)" (1 'php-block-statement))
+     
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()
      ("\\(->\\)\\(\\sw+\\)\\s-*(" (1 'php-object-op) (2 'php-method-call))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1574,7 +1574,7 @@ a completion list."
      ("\\(static\\)\\(?:[[:space:]]private\\|[[:space:]]protected\\|[[:space:]]public\\)?\\(?:[[:space:]]\$?[[:word:]]+\\)\\(?:[[:space:]]*=[[:space:]]*[^;]+\\)?\\(?:;\\)" (1 'php-property-static))
 
      ;; Block statements (if, elseif, for, foreach, catch, switch, while, declare)
-     ("\\(if\\|elseif\\|for\\|foreach\\|catch\\|switch\\|while\\|declare\\)\\(?:[[:space:]]*\([[:space:]]*.*[[:space:]]*\)\\)" (1 'php-block-statement))
+     ("if\\|elseif\\|for\\|foreach\\|catch\\|switch\\|while\\|declare" . 'php-block-statement)
      
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()

--- a/php-mode.el
+++ b/php-mode.el
@@ -1574,7 +1574,7 @@ a completion list."
      ("\\(static\\)\\(?:[[:space:]]private\\|[[:space:]]protected\\|[[:space:]]public\\)?\\(?:[[:space:]]\$?[[:word:]]+\\)\\(?:[[:space:]]*=[[:space:]]*[^;]+\\)?\\(?:;\\)" (1 'php-property-static))
 
      ;; Block statements (if, elseif, for, foreach, catch, switch, while, declare)
-     ("if\\|elseif\\|for\\|foreach\\|catch\\|switch\\|while\\|declare" . 'php-block-statement)
+     ("\\(if\\|elseif\\|for\\|foreach\\|catch\\|switch\\|while\\|declare\\)\\(?:[[:space:]]*(\\)" (1 'php-block-statement))
 
      ;; Flow control statements (break, continue, die, exit, goto, return, throw)
      ("break\\|continue\\|die\\|exit\\|goto\\|return\\|throw" . 'php-flow-control-statement)

--- a/php-mode.el
+++ b/php-mode.el
@@ -1582,6 +1582,9 @@ a completion list."
      ;; Print statements (echo, print, var_dump)
      ("echo\\|print\\|var_dump" . 'php-print-statement)
 
+     ;; Type operators (insteadof, instanceof)
+     ("insteadof\\|instanceof" . 'php-type-operator)
+
      ;; Include statements (include, include_once, require, require_once)
      ("include[^_]\\|include_once\\|require[^_]\\|require_once" . 'php-include-statement)
 
@@ -1722,6 +1725,9 @@ a completion list."
      ;; Not operator (!) is defined in "before cc-mode" section above.
      ("\\(&&\\|||\\)" 1 'php-logical-op)
 
+     ;; String operator (.)
+     ("\\(?:[^0-9[:space:]]\\)\\([[:space:]]*\\.[[:space:]]*\\)\\(?:[^0-9[:space:]]\\)" . (1 'php-string-op))
+     
      ;; Block delimiters ((, ), [, ], {, })
      ("\(\\|\)\\|\[\\|\]\\|\{\\|\}" . 'php-block-delimiter)
 

--- a/php-mode.el
+++ b/php-mode.el
@@ -1554,6 +1554,9 @@ a completion list."
 
      ;; Class modifiers (abstract, final)
      ("\\(abstract\\|final\\)[[:space:]]\\(?:class\\)" (1 'php-modifiers-class))
+
+     ;; Method modifiers (abstract, final, static)
+     ("\\(abstract\\|final\\)[[:space:]]\\(?:static[[:space:]]\\)?\\(?:public\\|private\\|protected\\)" (1 'php-modifiers-method))
      
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()

--- a/php-mode.el
+++ b/php-mode.el
@@ -1569,11 +1569,10 @@ a completion list."
      
      ;; Property access protection
      ("\\(private\\|protected\\|public\\)\\(?:[[:space:]]static\\|[[:space:]]const\\)?\\(?:[[:space:]]\$?[[:word:]]+\\)\\(?:[[:space:]]*=[[:space:]]*[^;]+\\)?\\(?:;\\)" (1 'php-property-access))
-     ;("\\(private\\|protected\\|public\\)[[:space:]]\\(?:const[[:space:]][^\$][[:word:]]\\|\$[[:word:]]\\)" (1 'php-property-access))
 
      ;; Property static modifier
-     ;;("\\(static\\)[[:space:]]\\(?:public\\|protected\\|private\\)" (1 'php-property-static))
-     
+     ("\\(static\\)\\(?:[[:space:]]private\\|[[:space:]]protected\\|[[:space:]]public\\)?\\(?:[[:space:]]\$?[[:word:]]+\\)\\(?:[[:space:]]*=[[:space:]]*[^;]+\\)?\\(?:;\\)" (1 'php-property-static))
+  
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()
      ("\\(->\\)\\(\\sw+\\)\\s-*(" (1 'php-object-op) (2 'php-method-call))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1584,6 +1584,9 @@ a completion list."
 
      ;; Include statements (include, include_once, require, require_once)
      ("include[^_]\\|include_once\\|require[^_]\\|require_once" . 'php-include-statement)
+
+     ;; Constant keywords
+     ("true\\|false\\|null" . 'php-constant-keyword)
      
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()

--- a/php-mode.el
+++ b/php-mode.el
@@ -1,4 +1,4 @@
-3;;; php-mode.el --- Major mode for editing PHP code
+;;; php-mode.el --- Major mode for editing PHP code
 
 ;; Copyright (C) 2018-2019  Friends of Emacs-PHP development
 ;; Copyright (C) 1999, 2000, 2001, 2003, 2004 Turadg Aleahmad
@@ -1546,10 +1546,11 @@ a completion list."
      ("implements\\|extends" . 'php-class-declaration-spec)
 
      ;; Namespace declaration
-     ("namespace" .  'php-namespace-declaration)
+     ("namespace" . 'php-namespace-declaration)
 
-     ;; import statement
-     ("use\\|as" . 'php-import-declaration)
+     ;; import statement (use ... as ...)
+     ("\\(use[[:space:]]\\)\\(?:[[:word:]\\]\\)" (1 'php-import-declaration))
+     ("\\(?:[[:word:]\\]\\)\\([[:space:]]as\\)" (1 'php-import-declaration))
      
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()
@@ -1638,7 +1639,7 @@ a completion list."
 
      ;; Highlight class name after "use .. as"
      ("\\<as\\s-+\\(\\sw+\\)" 1 font-lock-type-face)
-
+     
      ;; Class names are highlighted by cc-mode as defined in
      ;; c-class-decl-kwds, below regexp is a workaround for a bug
      ;; where the class names are not highlighted right after opening

--- a/php-mode.el
+++ b/php-mode.el
@@ -1540,7 +1540,7 @@ a completion list."
    ;;  a different face.
    `(
      ;; Class declaration keywords (class, trait, interface)
-     ("\\class\\|trait\\interface" . 'php-class-declaration)
+     ("class\\|trait\\|interface" . 'php-class-declaration)
      
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()

--- a/php-mode.el
+++ b/php-mode.el
@@ -1699,6 +1699,9 @@ a completion list."
      ;; Highlight the ? character for nullable type hints.
      ("\\(\\?\\)\\(:?\\sw\\|\\s_\\|\\\\\\)+\\s-+\\$" 1 font-lock-type-face)
 
+     ;; Highlight the : character in front of return types.
+     ("\\(?:function[[:space:]]+[[:word:]]+([[:word:][:space:],\$\\]*)\\)\\(:\\)" (1 'php-return-type-colon))
+
      ;; Class names without a namespace are not highlighted at all when they
      ;; are used as nullable type hints or return types (both nullable and
      ;; non-nullable). We have to use separate regular expressions, because

--- a/php-mode.el
+++ b/php-mode.el
@@ -1722,6 +1722,9 @@ a completion list."
      ;; Not operator (!) is defined in "before cc-mode" section above.
      ("\\(&&\\|||\\)" 1 'php-logical-op)
 
+     ;; Block delimiters ((, ), [, ], {, })
+     ("\(\\|\)\\|\[\\|\]\\|\{\\|\}" . 'php-block-delimiter)
+
      ;; Numbers
      ("[0-9]+\\.?" . 'php-number)))
   "Detailed highlighting for PHP Mode.")

--- a/php-mode.el
+++ b/php-mode.el
@@ -1547,6 +1547,9 @@ a completion list."
 
      ;; Namespace declaration
      ("namespace" .  'php-namespace-declaration)
+
+     ;; import statement
+     ("use\\|as" . 'php-import-declaration)
      
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()

--- a/php-mode.el
+++ b/php-mode.el
@@ -1559,7 +1559,10 @@ a completion list."
      ("\\(abstract\\|final\\)[[:space:]]\\(?:static\\|public\\|private\\|protected\\)" (1 'php-method-modifiers))
 
      ;; Method access protection
-     
+     ("\\(private\\|protected\\|public\\)[[:space:]]\\(?:static\\|function\\)" (1 'php-method-access))
+
+     ;; Method static modifier
+     ("\\(static\\)[[:space:]]\\(?:public\\|protected\\|private\\|function\\)" (1 'php-method-static))
      
      ;; Property access protection
      ;("\\(private\\|protected\\|public\\)\\(?:[[:space:]]const[[:space:]][[:word:]]\\|[[:space:]]\$[[:word:]]\\)" (1 'php-property-access))

--- a/php-mode.el
+++ b/php-mode.el
@@ -1553,10 +1553,16 @@ a completion list."
      ("\\(?:[[:word:]\\]\\)\\([[:space:]]as\\)" (1 'php-import-declaration))
 
      ;; Class modifiers (abstract, final)
-     ("\\(abstract\\|final\\)[[:space:]]\\(?:class\\)" (1 'php-modifiers-class))
+     ("\\(abstract\\|final\\)[[:space:]]\\(?:class\\)" (1 'php-class-modifiers))
 
-     ;; Method modifiers (abstract, final, static)
-     ("\\(abstract\\|final\\)[[:space:]]\\(?:static[[:space:]]\\)?\\(?:public\\|private\\|protected\\)" (1 'php-modifiers-method))
+     ;; Method modifiers (abstract, final)
+     ("\\(abstract\\|final\\)[[:space:]]\\(?:static\\|public\\|private\\|protected\\)" (1 'php-method-modifiers))
+
+     ;; Method access protection
+     
+     
+     ;; Property access protection
+     ;("\\(private\\|protected\\|public\\)\\(?:[[:space:]]const[[:space:]][[:word:]]\\|[[:space:]]\$[[:word:]]\\)" (1 'php-property-access))
      
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()

--- a/php-mode.el
+++ b/php-mode.el
@@ -1539,6 +1539,9 @@ a completion list."
    ;;  only add patterns here if you want to prevent cc-mode from applying
    ;;  a different face.
    `(
+     ;; Class declaration keywords (class, trait, interface)
+     ("\\class\\|trait\\interface" . 'php-class-declaration)
+     
      ;; Highlight variables, e.g. 'var' in '$var' and '$obj->var', but
      ;; not in $obj->var()
      ("\\(->\\)\\(\\sw+\\)\\s-*(" (1 'php-object-op) (2 'php-method-call))


### PR DESCRIPTION
Hello, this PR is adding a lot of new faces to php-mode. Let me explain what I have added.
The following faces (and accompanying regex) have been added:

### Classes
 - `php-class-declaration`: will fontify the words `class`, `trait`, `interface`.
 - `php-class-declaration-spec`: will fontify the words `implements`, `extends`.
 - `php-namespace-declaration`: will fontify the word `namespace`.
 - `php-import-declaration`: will fontify the words `use ... as ...`.
 - `php-class-modifier`: will fontify `abstract`, `final` keywords in class declaration.

### Methods
 - `php-method-modifier`: will fontify `abstract`, `final` keywords in method declaration.
 - `php-method-access`: will fontify `private`, `protected`, `public` in method declaration.
 - `php-method-static`: will fontify `static` keyword in method declaration.
 - `php-return-type-colon`: will fontify `:` in front of return type declaration.

### Properties
 - `php-property-access`: will fontify `private`, `protected`, `public` in property declaration.
 - `php-property-static`: will fontify `static` keyword in property declaration.
 - `php-property-const`: will fontify `const` keyword in property declaration.

### Statements
 - `php-block-statement`: will fontify `if`, `elseif`, `for`, `foreach`, `while`, `declare`, `switch` and `catch` keywords.
 - `php-flow-control-statement`: will fontify `break`, `continue`, `die`, `exit`, `goto`, `return` and `throw` keywords.
 - `php-print-statement`: will fontify `echo`, `print` and `var_dump` keywords.
 - `php-include-statement`: will fontify `include`, `include_once`, `require` and `require_once` keywords.

### Other Stuff
 - `php-constant-keyword`: will fontify `true`, `false` and `null`.
 - `php-function-keyword`: will fontify `function` in `... function name(...`.
 - `php-number`: will fontify integers and floats (`13`, `4.3`, `...`)
 - `php-string-quote`: will fontify the string delimiters (`'`, `"`)
 - `php-block-delimiter`: will fontify block delimiters (`(`, `[`, `{`, `)`, `]`, `}`)
 - `php-type-operator`: will fontify `insteadof` and `instanceof` keywords.
 - `php-string-op`: will fontify `.` for string concatenation. I also bootstrapped that in my last PR but somehow forgot to actually implement it.

### Default styles
The faces `php-type-operator`, `php-block-delimiter` and `php-number` inherit from `default`.
The face `php-string-quote` inherits from `php-string`.
All other faces inherit from `php-keyword`

So by default, everything should look the same.

### Known issues
 - when applying a different style to `php-string-qoute` in comparison to `php-string`, occurences of string delimiters inside of the string will also be colored differently. 
 - as usual, I believe most of the regex could be optimized in many ways. I'm open for suggestions as this is not my strong suite.
 - I know that `insteadof` is no type operator and therefore should not have been grouped in the `type-operator` face. However, since it's so similar to `instanceof` I put it in anyway.  