### PR TITLE
Add file extension .php.inc and .stub

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1693,6 +1693,7 @@ The output will appear in the buffer *PHP*."
 ;;;###autoload
 (progn
   (add-to-list 'auto-mode-alist '("/\\.php_cs\\(?:\\.dist\\)?\\'" . php-mode))
+  (add-to-list 'auto-mode-alist '("\\.\\(?:php\\.inc\\|stub\\)\\'" . php-mode))
   (add-to-list 'auto-mode-alist '("\\.\\(?:php[s345]?\\|phtml\\)\\'" . php-mode-maybe)))
 
 (provide 'php-mode)


### PR DESCRIPTION
`.php.inc` is file extension for [Rector](https://github.com/rectorphp/rector)'s test code.
`.stub` is file extension for [PHPStan's stub file](https://github.com/phpstan/phpstan-src/tree/master/stubs).