### PR TITLE
Ignore Emacs 27 break indentation in case

### DIFF
--- a/tests/issue-186.php
+++ b/tests/issue-186.php
@@ -21,7 +21,7 @@ switch (true) {
 case null:
 case false:
     echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
-    echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
+    echo 'test'; // Emacs27 breaks indentation in this case #612
 }
 
 switch (true) {

--- a/tests/issue-186.php
+++ b/tests/issue-186.php
@@ -37,3 +37,14 @@ case $test:
     echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
     echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
 }
+
+const AAA = 'AAA';
+const bbb = 'bbb';
+
+switch (true) {
+case AAA:
+case bbb:
+case 111:
+    echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
+    echo 'test'; // ###php-mode-test### ((indent (* c-basic-offset 2)))
+}


### PR DESCRIPTION
Fix #612

Certainly the indentation is broken, but the use case is not real.

<img width="591" alt="スクリーンショット 2020-03-22 18 11 02" src="https://user-images.githubusercontent.com/822086/77246248-d0944d00-6c68-11ea-83c0-0b61bd098f98.png">
