### PR TITLE
Add php-mode-disable-c-auto-align-backslashes for disable line continuation

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -298,6 +298,12 @@ In that case set to `NIL'."
   :tag "PHP Mode Enable Backup Style Variables"
   :type 'boolean)
 
+(defcustom php-mode-disable-c-auto-align-backslashes t
+  "When set to non-NIL, override `c-auto-align-backslashes' to NIL."
+  :group 'php-mode
+  :tag "PHP Mode Disable c-auto-align-backslashes"
+  :type 'boolean)
+
 (define-obsolete-variable-alias 'php-mode-disable-parent-mode-hooks 'php-mode-disable-c-mode-hook "1.21.0")
 (defcustom php-mode-disable-c-mode-hook t
   "When set to `T', do not run hooks of parent modes (`java-mode', `c-mode')."
@@ -855,6 +861,9 @@ reported, even if `c-report-syntactic-errors' is non-nil."
           php-warned-bad-indent
           (php-check-html-for-indentation))
       (let ((here (point))
+            (c-auto-align-backslashes
+             (unless php-mode-disable-c-auto-align-backslashes
+               c-auto-align-backslashes))
             doit)
         (move-beginning-of-line nil)
         ;; Don't indent heredoc end mark


### PR DESCRIPTION
refs https://github.com/emacs-php/php-mode/issues/620