### PR TITLE
Fix regexp where characters following logical negation are not font-locked

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -1518,7 +1518,7 @@ a completion list."
      ("\\<\\(const\\)\\s-+\\(\\_<.+?\\_>\\)" (1 'php-keyword) (2 'php-constant-assign))
 
      ;; Logical operator (!)
-     ("\\(![^=]\\)" 1 'php-logical-op)
+     ("\\(!\\)[^=]" 1 'php-logical-op)
 
      ;; Highlight special variables
      ("\\(\\$\\)\\(this\\)\\>" (1 'php-$this-sigil) (2 'php-$this))


### PR DESCRIPTION
Fixes https://github.com/emacs-php/php-mode/pull/594/files#diff-6caa62262a5e21bf011a728cd018371fR1547