### PR TITLE
Add mixed type

### DIFF
--- a/php-mode.el
+++ b/php-mode.el
@@ -472,7 +472,7 @@ In that case set to `NIL'."
 
 (c-lang-defconst c-primitive-type-kwds
   php '("int" "integer" "bool" "boolean" "float" "double" "real"
-        "string" "object" "void"))
+        "string" "object" "void" "mixed"))
 
 (c-lang-defconst c-class-decl-kwds
   "Keywords introducing declarations where the following block (if any)

--- a/tests/lang/types/keywords.php
+++ b/tests/lang/types/keywords.php
@@ -12,3 +12,4 @@ real;
 string;
 object;
 resource;
+mixed;

--- a/tests/lang/types/keywords.php.faces
+++ b/tests/lang/types/keywords.php.faces
@@ -20,4 +20,6 @@
  ("string" . font-lock-type-face)
  (";\n")
  ("object" . font-lock-type-face)
- (";\nresource;\n"))
+ (";\nresource;\n")
+ ("mixed" . font-lock-type-face)
+ (";\n"))


### PR DESCRIPTION
`mixed` type declare is added in PHP 8.0.

Accept: [PHP RFC: Mixed Type v2](https://wiki.php.net/rfc/mixed_type_v2)