### PR TITLE
Add Keg for building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.cask/
+/.keg/
 /.mailmap
 /php-mode-autoloads.el
 *~

--- a/Keg
+++ b/Keg
@@ -1,0 +1,10 @@
+(source gnu melpa)
+
+(package
+ (php-mode
+  (recipe . (php-mode :fetcher github :repo "emacs-php/php-mode.el"
+                      :files (:defaults "lisp/*.el")))))
+
+(dev-dependency pkg-info)
+(dev-dependency projectile)
+(dev-dependency shut-up)


### PR DESCRIPTION
refs https://github.com/emacs-php/php-mode/issues/638

[Keg](https://github.com/conao3/keg.el) is a candidate to replace [Cask](https://github.com/cask/cask) in the future, but Cask is not yet removed.