### PR TITLE
Correct the heredoc regexp.

### DIFF
--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -970,7 +970,7 @@ this ^ lineup"
 
 (eval-and-compile
   (defconst php-heredoc-start-re
-    "<<<\\(?:\\_<.+?\\_>\\|'\\_<.+?\\_>'\\|\"\\_<.+?\\_>\"\\)$"
+    "<<<[ \t]*\\(?:\\_<.+?\\_>\\|'\\_<.+?\\_>'\\|\"\\_<.+?\\_>\"\\)$"
     "Regular expression for the start of a PHP heredoc."))
 
 (defun php-heredoc-end-re (heredoc-start)


### PR DESCRIPTION
To support heredoc in this style:
<<< 'HEREDOC'
instead of
<<<'HEREDOC'