### PR TITLE
Load cask in testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,17 @@ jobs:
           - emacs_version: snapshot
             allow_failure: true
     steps:
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.6'
+        architecture: 'x64'
     - uses: purcell/setup-emacs@master
       with:
         version: ${{ matrix.emacs_version }}
-
-    - uses: actions/checkout@v1
+    - uses: conao3/setup-cask@master
+      with:
+        version: 'snapshot'
+    - uses: actions/checkout@v2
     - name: Run tests
       if: matrix.allow_failure != true
       run: 'make test'

--- a/Cask
+++ b/Cask
@@ -1,15 +1,17 @@
 (package "php-mode" "1.24.0" "Major mode for editing PHP code")
 (source melpa)
 
-(package-file "php-mode.el")
+(package-file "lisp/php-mode.el")
 
 (files
- "php.el"
- "php-face.el"
- "php-project.el"
- "php-mode-debug.el")
+ "lisp/php.el"
+ "lisp/php-face.el"
+ "lisp/php-project.el"
+ "lisp/php-local-manual.el"
+ "lisp/php-mode-debug.el")
 
 (development
  (depends-on "pkg-info")
  (depends-on "projectile")
+ (depends-on "smart-jump")
  (depends-on "shut-up"))

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,11 @@ dev:
 # command.
 test: clean all
 	touch tests/project/1/.git
-	$(EMACS) -Q -batch -l lisp/php-mode-autoloads.el \
-	   -l tests/php-mode-test.el -f ert-run-tests-batch-and-exit
+	$(EMACS) -Q -batch -L lisp/ --eval \
+	"(let ((default-directory (expand-file-name \".cask\" default-directory))) \
+	   (require 'package) \
+	   (normal-top-level-add-subdirs-to-load-path))" \
+	    -f package-initialize \
+	    -l tests/php-mode-test.el -f ert-run-tests-batch-and-exit
 
 .PHONY: all authors autoloads clean test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 EMACS ?= emacs
+CASK ?= cask
 ELS = lisp/php.el lisp/php-align.el lisp/php-face.el lisp/php-project.el lisp/php-local-manual.el lisp/php-mode.el lisp/php-mode-debug.el
 AUTOLOADS = php-mode-autoloads.el
 ELCS = $(ELS:.el=.elc)
@@ -24,11 +25,14 @@ AUTHORS.md: etc/git/AUTHORS.md.in .mailmap
 
 autoloads: $(AUTOLOADS)
 
-$(AUTOLOADS): lisp/php.el lisp/php-align.el lisp/php-face.el lisp/php-project.el lisp/php-mode-debug.el lisp/php-mode.el
+$(AUTOLOADS): lisp/php.el lisp/php-align.el lisp/php-face.el lisp/php-project.el lisp/php-local-manual.el lisp/php-mode-debug.el lisp/php-mode.el
 	$(EMACS) -Q -batch -L lisp/ --eval \
 	"(progn \
 	   (require 'package) \
 	   (package-generate-autoloads \"php-mode\" (expand-file-name \"lisp\")))"
+
+.cask: Cask
+	$(CASK) install
 
 clean:
 	rm -f $(ELCS) $(AUTOLOADS)
@@ -50,7 +54,7 @@ dev:
 #
 # for an example of using a script like this with the 'git bisect run'
 # command.
-test: clean all
+test: .cask clean all
 	touch tests/project/1/.git
 	$(EMACS) -Q -batch -L lisp/ --eval \
 	"(let ((default-directory (expand-file-name \".cask\" default-directory))) \


### PR DESCRIPTION
External packages depend for testing. The application is not yet dependent on external packages.