### PR TITLE
Improve php-imenu-generic-expression

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run tests
       if: matrix.allow_failure != true
-      run: 'make test'
+      run: 'make .cask test'
     - name: Run tests (allow failure)
       if: matrix.allow_failure == true
       run: 'make test || true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
 
  * Support new PHP 8.0 and 8.1 syntax hilighting and indentation
     * [8.0] `#[Attributes]`
+ * Add `php-imenu-generic-expression-default` for default value or `php-imenu-generic-expression`
+
+### Changed
+
+ * Re-organized `php-imenu-generic-expression`
+   * Added `Import`, `Constants` and `Properties`
+   * Removed `Anonymous Functions`
+   * Renamed `Named Functions` to `Functions`
+   * Renamed `All Methods` to `Methods`
+   * Removed `Public Methods`, `Protected Methods` and `Provate Methods`
+   * Unified `Classes`, `Traits`, `Interfaces` into `Classes`
 
 ## [1.24.0] - 2021-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
  * Support new PHP 8.0 and 8.1 syntax hilighting and indentation
     * [8.0] `#[Attributes]`
  * Add `php-imenu-generic-expression-default` for default value or `php-imenu-generic-expression`
+   * Add `php-imenu-generic-expression-legacy` for compatibility
+   * Add `php-imenu-generic-expression-simple` for simple display
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ dev:
 #
 # for an example of using a script like this with the 'git bisect run'
 # command.
-test: .cask clean all
+test: clean all
 	touch tests/project/1/.git
 	$(EMACS) -Q -batch -L lisp/ --eval \
 	"(let ((default-directory (expand-file-name \".cask\" default-directory))) \

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -1195,7 +1195,9 @@ After setting the stylevars run hooks according to STYLENAME
   (add-hook 'syntax-propertize-extend-region-functions
             #'php-syntax-propertize-extend-region t t)
 
-  (setq imenu-generic-expression php-imenu-generic-expression)
+  (setq imenu-generic-expression (if (symbolp php-imenu-generic-expression)
+                                     (symbol-value php-imenu-generic-expression)
+                                   php-imenu-generic-expression))
 
   ;; PHP vars are case-sensitive
   (setq case-fold-search t)

--- a/lisp/php.el
+++ b/lisp/php.el
@@ -396,10 +396,12 @@ can be used to match against definitions for that classlike."
        "^\\s-*function\\s-+\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*(" 1)))
   "Imenu generic expression for PHP Mode.  See `imenu-generic-expression'.")
 
-(defcustom php-imenu-generic-expression php-imenu-generic-expression-default
+(defcustom php-imenu-generic-expression 'php-imenu-generic-expression-default
   "Default Imenu generic expression for PHP Mode.  See `imenu-generic-expression'."
-  :type '(alist :key-type string
-                :value-type list)
+  :type '(choice (alist :key-type string :value-type list)
+                 (const 'php-imenu-generic-expression-legacy)
+                 (const 'php-imenu-generic-expression-simple)
+                 variable)
   :group 'php)
 
 (defconst php--re-namespace-pattern

--- a/lisp/php.el
+++ b/lisp/php.el
@@ -332,6 +332,70 @@ can be used to match against definitions for that classlike."
        ,(php-create-regexp-for-classlike "namespace") 1)))
   "Imenu generic expression for PHP Mode.  See `imenu-generic-expression'.")
 
+(defconst php-imenu-generic-expression-simple
+  (eval-when-compile
+    `(("Methods"
+       ,(php-create-regexp-for-method nil) 2)
+      ("Properties"
+       ,(rx line-start
+            (* (syntax whitespace))
+            (+ (or "public" "protected" "private" "static" "var")
+               (+ (syntax whitespace)))
+            (* (? (? (or "|" "?"))
+                  (or "\\" (syntax word) (syntax symbol))
+                  (+ (syntax whitespace))))
+            (group
+             "$" (+ (or (syntax word) (syntax symbol))))
+            word-boundary)
+       1)
+      ("Constants"
+       ,(rx line-start
+            (* (syntax whitespace))
+            (group
+             (* (or "public" "protected" "private")
+                (+ (syntax whitespace)))
+             "const"
+             (+ (syntax whitespace))
+             (+ (or (syntax word) (syntax symbol)))))
+       1)
+      ("Functions"
+       ,(rx line-start
+            (* (syntax whitespace))
+            "function"
+            (+ (syntax whitespace))
+            (group
+             (+ (or (syntax word) (syntax symbol)))))
+       1)
+      ("Classes"
+       ,(php-create-regexp-for-classlike "\\(?:class\\|interface\\|trait\\|enum\\)") 1)
+      ("Namespace"
+       ,(php-create-regexp-for-classlike "namespace") 1)))
+  "Imenu generic expression for PHP Mode.  See `imenu-generic-expression'.")
+
+(defconst php-imenu-generic-expression-legacy
+  (eval-when-compile
+    `(("Namespaces"
+       ,(php-create-regexp-for-classlike "namespace") 1)
+      ("Classes"
+       ,(php-create-regexp-for-classlike "class") 1)
+      ("Interfaces"
+       ,(php-create-regexp-for-classlike "interface") 1)
+      ("Traits"
+       ,(php-create-regexp-for-classlike "trait") 1)
+      ("All Methods"
+       ,(php-create-regexp-for-method) 1)
+      ("Private Methods"
+       ,(php-create-regexp-for-method '("private")) 2)
+      ("Protected Methods"
+       ,(php-create-regexp-for-method '("protected"))  2)
+      ("Public Methods"
+       ,(php-create-regexp-for-method '("public")) 2)
+      ("Anonymous Functions"
+       "\\<\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*=\\s-*f\\(unctio\\)?n\\s-*(" 1)
+      ("Named Functions"
+       "^\\s-*function\\s-+\\(\\(?:\\sw\\|\\s_\\)+\\)\\s-*(" 1)))
+  "Imenu generic expression for PHP Mode.  See `imenu-generic-expression'.")
+
 (defcustom php-imenu-generic-expression php-imenu-generic-expression-default
   "Default Imenu generic expression for PHP Mode.  See `imenu-generic-expression'."
   :type '(alist :key-type string

--- a/tests/php-mode-test.el
+++ b/tests/php-mode-test.el
@@ -319,12 +319,9 @@ style from Drupal."
   "All static method should appear on imenu whether 'static' keyword is placed before or after visibility"
   (with-php-mode-test ("issue-83.php")
     (let* ((index-alist (imenu--make-index-alist))
-           (public-methods (mapcar 'car (cdr (assoc "Public Methods" index-alist))))
-           (all-methods (mapcar 'car (cdr (assoc "All Methods" index-alist)))))
-      (should (member "staticBeforeVisibility" public-methods))
-      (should (member "staticBeforeVisibility" all-methods))
-      (should (member "staticAfterVisibility" public-methods))
-      (should (member "staticAfterVisibility" all-methods)))))
+           (all-methods (mapcar 'car (cdr (assoc "Methods" index-alist)))))
+      (should (member "static public function staticBeforeVisibility()" all-methods))
+      (should (member "public static function staticAfterVisibility()" all-methods)))))
 
 (ert-deftest php-mode-test-issue-99 ()
   "Proper indentation for 'foreach' statements without braces."

--- a/tests/php-mode-test.el
+++ b/tests/php-mode-test.el
@@ -320,8 +320,10 @@ style from Drupal."
   (with-php-mode-test ("issue-83.php")
     (let* ((index-alist (imenu--make-index-alist))
            (all-methods (mapcar 'car (cdr (assoc "Methods" index-alist)))))
-      (should (member "static public function staticBeforeVisibility()" all-methods))
-      (should (member "public static function staticAfterVisibility()" all-methods)))))
+      (should (equal all-methods
+                     (list
+                      "static public function staticBeforeVisibility()"
+                      "public static function staticAfterVisibility()"))))))
 
 (ert-deftest php-mode-test-issue-99 ()
   "Proper indentation for 'foreach' statements without braces."


### PR DESCRIPTION
The old list had duplicate items and lacked an index of modern syntax elements.
Modern PHP code focuses on building one class per file. (PSR-4)

We recommend using [bmag/imenu-list](https://github.com/bmag/imenu-list) instead of imenu.

## Customization

```el
;; For simple display
(custom-set-variables '(php-imenu-generic-expression 'php-imenu-generic-expression-simple))

;; For compatibility
(custom-set-variables '(php-imenu-generic-expression 'php-imenu-generic-expression-legacy))
```

## Screen shot

### Before

<img width="184" alt="スクリーンショット 2021-05-10 4 44 51" src="https://user-images.githubusercontent.com/822086/117585707-cf64fe80-b14e-11eb-8ad1-b7545d9544f5.png">

### After

<img width="303" alt="スクリーンショット 2021-05-10 4 37 50" src="https://user-images.githubusercontent.com/822086/117585718-d986fd00-b14e-11eb-9984-92b7193472b9.png">

### Simple

<img width="159" alt="スクリーンショット 2021-05-10 21 31 12" src="https://user-images.githubusercontent.com/822086/117662312-61feaf80-b1da-11eb-9a01-3927c07d343f.png">
