### PR TITLE
Move php-completion functions to local manual

### DIFF
--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -1355,27 +1355,6 @@ current `tags-file-name'."
            collect (replace-regexp-in-string
                     "-" "_" (substring file (match-beginning 1) (match-end 1)) t)))
 
-;; Find the pattern we want to complete
-;; find-tag-default from GNU Emacs etags.el
-(defun php-get-pattern ()
-  (save-excursion
-    (while (looking-at "\\sw\\|\\s_")
-      (forward-char 1))
-    (if (or (re-search-backward "\\sw\\|\\s_"
-                                (save-excursion (beginning-of-line) (point))
-                                t)
-            (re-search-forward "\\(\\sw\\|\\s_\\)+"
-                               (save-excursion (end-of-line) (point))
-                               t))
-        (progn (goto-char (match-end 0))
-               (buffer-substring-no-properties
-                (point)
-                (progn (forward-sexp -1)
-                       (while (looking-at "\\s'")
-                         (forward-char 1))
-                       (point))))
-      nil)))
-
 (defun php-show-arglist ()
   "Show function arguments at cursor position."
   (interactive)

--- a/lisp/php.el
+++ b/lisp/php.el
@@ -419,6 +419,28 @@ can be used to match against definitions for that classlike."
       (when (re-search-backward re-pattern nil t)
         (match-string-no-properties 1)))))
 
+(defun php-get-pattern ()
+  "Find the pattern we want to complete.
+`find-tag-default' from GNU Emacs etags.el"
+  (save-excursion
+    (save-match-data
+      (while (looking-at "\\sw\\|\\s_")
+        (forward-char 1))
+      (when (or (re-search-backward "\\sw\\|\\s_"
+                                    (save-excursion (beginning-of-line) (point))
+                                    t)
+                (re-search-forward "\\(\\sw\\|\\s_\\)+"
+                                   (save-excursion (end-of-line) (point))
+                                   t))
+        (goto-char (match-end 0))
+        (buffer-substring-no-properties
+         (point)
+         (progn
+           (forward-sexp -1)
+           (while (looking-at "\\s'")
+             (forward-char 1))
+           (point)))))))
+
 ;;; Provide support for Flymake so that users can see warnings and
 ;;; errors in real-time as they write code.
 (defun php-flymake-php-init ()


### PR DESCRIPTION
Separate local file dependent completion functions into `php-local-manual`.