### PR TITLE
Add lexical-binding: t

### DIFF
--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -1,4 +1,4 @@
-;;; php-mode.el --- Major mode for editing PHP code
+;;; php-mode.el --- Major mode for editing PHP code  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2020  Friends of Emacs-PHP development
 ;; Copyright (C) 1999, 2000, 2001, 2003, 2004 Turadg Aleahmad


### PR DESCRIPTION
It was not marked as `lexical-binding` for compatibility with Emacs 23 and earlier. You don't have to keep it today.

This change will slightly improve the performance of closures created with this file, but you may not experience it.