### PR TITLE
Fix a 404 link and change to use "https"

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -166,7 +166,7 @@ PHPDocは[JavaDoc](https://en.wikipedia.org/wiki/Javadoc)に似たドキュメ�
 
 **アノテーション**と呼ばれる記法は部分的にサポートしています。アノテーションの文法はタグとは少し異なり、`@Annotation(attr1="vvv", attr2="zzz")` のような形式です。
 
-[Symfony](http://symfony.com/)プロジェクトや[Go! AOP](https://github.com/goaop/framework)などいくつかのプロジェクト・フレームワークは[Doctrine Annotations](http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/annotations.html)の文法を元にしています。
+[Symfony](https://symfony.com/)プロジェクトや[Go! AOP](https://github.com/goaop/framework)などいくつかのプロジェクト・フレームワークは[Doctrine Annotations](https://www.doctrine-project.org/projects/doctrine-annotations/en/latest/index.html)の文法を元にしています。
 
 ```php
 /**

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ There are `@param`, `@return`, `@var`... etc in the notation called **tag**, loo
 
 In addition, it also partially supports notation called **annotation**.  Annotation has a slightly different grammar from tag, and the example is `@Annotation(attr1="vvv", attr2="zzz")`.
 
-[Symfony](http://symfony.com/) project and [Go! AOP](https://github.com/goaop/framework) and some projects/frameworks use annotation grammer based on [Doctrine Annotations](http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/annotations.html).
+[Symfony](https://symfony.com/) project and [Go! AOP](https://github.com/goaop/framework) and some projects/frameworks use annotation grammer based on [Doctrine Annotations](https://www.doctrine-project.org/projects/doctrine-annotations/en/latest/index.html).
 
 ```php
 /**


### PR DESCRIPTION
## About

- Fix a 404 not found link
    - OLD: http://docs.doctrine-project.org/projects/doctrine-common/en/latest/reference/annotations.html
    - NEW: https://www.doctrine-project.org/projects/doctrine-annotations/en/latest/index.html
- Use the "https"
    - OLD: http://symfony.com/
    - NEW: https://symfony.com/

