### PR TITLE
No inherit c-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
 
 ### Changed
 
+ * `php-mode` no longer inherits `c-mode`
+   * The keymap continues to inherit from `c-mode-base-map`.
+   * This change has no effect on other CC Mode features
  * Optimized propertize process ([#669])
    * Reimoplement `php-syntax-propertize-function` using `syntax-propertize-rules`
    * Make propertize PHP 8 `#[Attribute]` always enabled

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -299,6 +299,7 @@ In that case set to `NIL'."
 
 (defvar php-mode-map
   (let ((map (make-sparse-keymap "PHP Mode")))
+    (set-keymap-parent map c-mode-base-map)
     ;; Remove menu item for c-mode
     (define-key map [menu-bar C] nil)
 
@@ -1099,13 +1100,13 @@ After setting the stylevars run hooks according to STYLENAME
     table))
 
 ;;;###autoload
-(define-derived-mode php-mode c-mode "PHP"
+(define-derived-mode php-mode prog-mode "PHP"
   "Major mode for editing PHP code.
 
 \\{php-mode-map}"
+  :group 'php-mode
   :syntax-table php-mode-syntax-table
-  ;; :after-hook (c-update-modeline)
-  ;; (setq abbrev-mode t)
+  :after-hook (c-update-modeline)
 
   (unless (string= php-mode-cc-vertion c-version)
     (user-error "CC Mode has been updated.  %s"

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -271,13 +271,6 @@ In that case set to `NIL'."
   :tag "PHP Mode Disable c-auto-align-backslashes"
   :type 'boolean)
 
-(define-obsolete-variable-alias 'php-mode-disable-parent-mode-hooks 'php-mode-disable-c-mode-hook "1.21.0")
-(defcustom php-mode-disable-c-mode-hook t
-  "When set to `T', do not run hooks of parent modes (`java-mode', `c-mode')."
-  :group 'php-mode
-  :tag "PHP Mode Disable C Mode Hook"
-  :type 'boolean)
-
 (defcustom php-mode-enable-project-local-variable t
   "When set to `T', apply project local variable to buffer local variable."
   :group 'php-mode
@@ -1120,9 +1113,6 @@ After setting the stylevars run hooks according to STYLENAME
                     "Please run `M-x package-reinstall php-mode' command."
                   "Please byte recompile PHP Mode files.")))
 
-  (when php-mode-disable-c-mode-hook
-    (setq-local c-mode-hook nil)
-    (setq-local java-mode-hook nil))
   (c-initialize-cc-mode t)
   (c-init-language-vars php-mode)
   (c-common-init 'php-mode)


### PR DESCRIPTION
This change is part of an attempt to separate the c-mode and php-mode dependencies.

PHP Mode still depends on [CC Mode](https://www.gnu.org/software/emacs/manual/html_mono/ccmode.html). However, PHP has nothing to do with C language, so I will separate that part.

`php-mode-map` inherits from `c-mode-base-map`, so use it for common key bindings with `c-mode`.