### PR TITLE
Properly list the credits of all previous contributors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -49,15 +49,15 @@ Names Sorted Alphabetically:
 - Engelke Eschner
 - Eric James Michael Ritz
 - Eric Mc Sween
-- Fred Yankowski
 - François-Xavier Bois
+- Fred Yankowski
 - Gerrit Riessen
 - Giacomo Tesio
 - Gregory Stark
 - Gu Weigang
-- Ian Eure
 - Herbert Jones
 - Hernawan Fa'iz Abdillah
+- Ian Eure
 - Jacek Wysocki
 - Jakub Jankiewicz
 - James Laver
@@ -91,12 +91,12 @@ Names Sorted Alphabetically:
 - Sean Champ
 - Sebastian Wiesner
 - Serghei Iakovlev
-- Syohei YOSHIDA
 - Stefan Monnier
 - Stig Bakken
-- Torsten Martinsen
+- Syohei YOSHIDA
 - Tim Landscheidt
 - Tom Willemsen
+- Torsten Martinsen
 - U-CPT\deb
 - USAMI Kenta
 - Valentin Funk

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -114,3 +114,7 @@ Names Sorted Alphabetically:
 - tijsmallaerts
 - zapad
 - 顾伟刚
+
+A chronological list of pre-2019 contributors can be found at [wiki/Authors](https://github.com/emacs-php/php-mode/wiki/Authors).
+
+Contributors since 2011, where this project was hosted, can also be found at [graphs/contributors](https://github.com/emacs-php/php-mode/graphs/contributors), except for accounts that have been withdrawn from GitHub.

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ AUTHORS.md: etc/git/AUTHORS.md.in .mailmap
 	@printf "Generating AUTHORS.md file..."
 	@test -d .git \
 		&& (cat $< > $@ \
-			&& git log --pretty=format:'- %aN' | LANG=C sort -u >> $@ \
+			&& git log --pretty=format:'- %aN' | \
+			cat etc/git/former-contributors - | LANG=C sort -u >> $@ \
 			&& printf "FINISHED\n" ; ) \
 		|| printf "FAILED (non-fatal)\n"
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ AUTHORS.md: etc/git/AUTHORS.md.in .mailmap
 		&& (cat $< > $@ \
 			&& git log --pretty=format:'- %aN' | \
 			cat etc/git/former-contributors - | LANG=C sort -u >> $@ \
+			&& cat etc/git/AUTHORS2.md.in >> $@ \
 			&& printf "FINISHED\n" ; ) \
 		|| printf "FAILED (non-fatal)\n"
 

--- a/etc/git/AUTHORS2.md.in
+++ b/etc/git/AUTHORS2.md.in
@@ -1,0 +1,4 @@
+
+A chronological list of pre-2019 contributors can be found at [wiki/Authors](https://github.com/emacs-php/php-mode/wiki/Authors).
+
+Contributors since 2011, where this project was hosted, can also be found at [graphs/contributors](https://github.com/emacs-php/php-mode/graphs/contributors), except for accounts that have been withdrawn from GitHub.

--- a/etc/git/former-contributors
+++ b/etc/git/former-contributors
@@ -1,0 +1,33 @@
+- Aaron S. Hawley
+- Bill Lovett
+- Boris Folgmann
+- Chris Morris
+- Craig Andrews
+- David House
+- Dias Badekas
+- Doug Marcey
+- Eric Mc Sween
+- Fred Yankowski
+- Gerrit Riessen
+- Giacomo Tesio
+- Gregory Stark
+- Ian Eure
+- John Keller
+- Juanjo
+- Kevin Blake
+- Lennart Borgman
+- Mathias Meyer
+- Nils Rennebarth
+- Rex McMaster
+- Roland
+- Rosenfeld
+- Ryan
+- Sammartino
+- Sean Champ
+- Stefan Monnier
+- Stig Bakken
+- Torsten Martinsen
+- Valentin Funk
+- Ville Skytta
+- Vinai Kopp
+- ppercot


### PR DESCRIPTION
Fixed many omissions that occurred when separating the contributor list from the `README.md` to `AUTHORS.md`.

refs https://github.com/emacs-php/php-mode/issues/685, fixes https://github.com/emacs-php/php-mode/pull/607 and closes https://github.com/emacs-php/php-mode/pull/686. Thanks to @Shamar for reporting this issue.

