### PR TITLE
Skip PHP8.1 tests when exec is not found

### DIFF
--- a/tests/php-mode-test.el
+++ b/tests/php-mode-test.el
@@ -659,6 +659,7 @@ Meant for `php-mode-test-issue-503'."
 
 (ert-deftest php-mode-test-php81 ()
   "Test highlighting language constructs added in PHP 8.1."
+  (skip-unless (executable-find "php8.1"))
   (with-php-mode-test ("8.1/enum.php" :faces t))
   (with-php-mode-test ("8.1/readonly.php" :faces t)))
 


### PR DESCRIPTION
Hi,  I had to add this patch to the Debian package when PHP8.1 was still in beta, but I've decided to retain it so that self-tests can still run, and pass, successfully on systems that don't have PHP8.1.  For example, this allows Ubuntu's CI to pass if someone updates the package in one of their LTS releases.