### PR TITLE
Add php-project-project-find-function compatible with project-find-functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
  * Add `php-imenu-generic-expression-default` for default value or `php-imenu-generic-expression`
    * Add `php-imenu-generic-expression-legacy` for compatibility
    * Add `php-imenu-generic-expression-simple` for simple display
+ * Add `php-project-project-find-function` compatible with `project-find-functions`
 
 ### Changed
 

--- a/lisp/php-project.el
+++ b/lisp/php-project.el
@@ -282,6 +282,17 @@ Typically it is `pear', `drupal', `wordpress', `symfony2' and `psr2'.")
       php-project-root
     (php-project--detect-root-dir)))
 
+;;;###autoload
+(defun php-project-project-find-function (dir)
+  "Return path to current PHP project from DIR.
+
+This function is compatible with `project-find-functions'."
+  (let ((default-directory dir))
+    (when-let (root (php-project-get-root-dir))
+      (if (file-exists-p (expand-file-name ".git" root))
+          (cons 'vc root)
+        (cons 'transient root)))))
+
 (defun php-project--detect-root-dir ()
   "Return detected project root."
   (if (and php-project-use-projectile-to-detect-root


### PR DESCRIPTION
This function can be used to find the project root when `vc-backends` is disabled.

```el
(add-hook 'project-find-functions #'php-project-project-find-function 0 t)
```
