### PR TITLE
Remove (c-lang-defconst c-opt-<>-sexp-key)

### DIFF
--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -572,9 +572,6 @@ might be to handle switch and goto labels differently."
   php (cl-remove-if (lambda (elm) (and (listp elm) (memq 'c-annotation-face elm)))
                     (c-lang-const c-basic-matchers-after php)))
 
-(c-lang-defconst c-opt-<>-sexp-key
-  php nil)
-
 (defconst php-mode--re-return-typed-closure
   (eval-when-compile
     (rx symbol-start "function" symbol-end


### PR DESCRIPTION
refs https://github.com/emacs-php/php-mode/issues/702, fixed https://github.com/emacs-php/php-mode/pull/519/commits/8a437100f6b2bbb84bc8aee8577ba302922d2af1