### PR TITLE
Add @phpstan-self-out and @phpstan-this-out keywords

### DIFF
--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -1287,11 +1287,11 @@ for \\[find-tag] (which see)."
         "never" "never-return" "never-returns" "no-return" "non-empty-array"
         "non-empty-list" "non-empty-string" "non-falsy-string"
         "numeric" "numeric-string" "positive-int" "scalar"
-        "trait-string" "truthy-string" "self-out" "this-out"))
+        "trait-string" "truthy-string"))
 
 (defconst php-phpdoc-type-tags
   (list "package" "param" "property" "property-read" "property-write"
-        "return" "throws" "var"))
+        "return" "throws" "var" "self-out" "this-out"))
 
 (defconst php-phpdoc-font-lock-doc-comments
   `(("{@[-[:alpha:]]+\\s-*\\([^}]*\\)}" ; "{@foo ...}" markup.

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -1287,7 +1287,7 @@ for \\[find-tag] (which see)."
         "never" "never-return" "never-returns" "no-return" "non-empty-array"
         "non-empty-list" "non-empty-string" "non-falsy-string"
         "numeric" "numeric-string" "positive-int" "scalar"
-        "trait-string" "truthy-string"))
+        "trait-string" "truthy-string" "self-out" "this-out"))
 
 (defconst php-phpdoc-type-tags
   (list "package" "param" "property" "property-read" "property-write"


### PR DESCRIPTION
ref: https://phpstan.org/blog/phpstan-1-9-0-with-phpdoc-asserts-list-type#describe-type-of-current-object-after-calling-a-method