### PR TITLE
Add php-mode-debug-reinstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
        * Psalm: [Supported Annotations](https://psalm.dev/docs/annotating_code/supported_annotations/)
        * Psalm: [Template Annotations](https://psalm.dev/docs/annotating_code/templated_annotations/)
  * Add `php-mode-replace-flymake-diag-function` custom variable and default activated it ([#718])
+ * Add `php-mode-debug-reinstall` command to help users who update Emacs themselves ([#721])
 
 ### Changed
 
@@ -55,6 +56,7 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
 [#717]: https://github.com/emacs-php/php-mode/pull/717
 [#718]: https://github.com/emacs-php/php-mode/pull/718
 [#719]: https://github.com/emacs-php/php-mode/pull/719
+[#721]: https://github.com/emacs-php/php-mode/pull/721
 
 ## [1.24.1] - 2022-10-08
 

--- a/lisp/php-mode-debug.el
+++ b/lisp/php-mode-debug.el
@@ -105,7 +105,12 @@ When CALLED-INTERACTIVE then message the result."
   (php-mode-debug--message "Pasting the following information on the issue will help us to investigate the cause.")
   (php-mode-debug--message "```")
   (php-mode-debug--message "--- PHP-MODE DEBUG BEGIN ---")
-  (php-mode-debug--message "versions: %s; %s; Cc Mode %s)" (emacs-version) (php-mode-version) c-version)
+  (php-mode-debug--message "versions: %s; %s; Cc Mode %s)"
+    (emacs-version)
+    (php-mode-version)
+    (if (string= php-mode-cc-version c-version)
+        c-version
+      (format "%s (php-mode-cc-version: %s *mismatched*)" c-version php-mode-cc-version)))
   (php-mode-debug--message "package-version: %s"
     (if (fboundp 'pkg-info)
         (pkg-info-version-info 'php-mode)

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -115,6 +115,13 @@ The format is follows:
 
 (autoload 'php-mode-debug "php-mode-debug"
   "Display informations useful for debugging PHP Mode." t)
+
+(autoload 'php-mode-debug-reinstall "php-mode-debug"
+  "Reinstall PHP Mode to solve Cc Mode version mismatch.
+
+When FORCE, try to reinstall without interactively asking.
+When CALLED-INTERACTIVE then message the result." t)
+
 
 ;; Local variables
 
@@ -316,7 +323,7 @@ In that case set to `NIL'."
   :tag "PHP Mode Enable Project Local Variable"
   :type 'boolean)
 
-(defconst php-mode-cc-vertion
+(defconst php-mode-cc-version
   (eval-when-compile c-version))
 
 (cl-defun php-mode-version (&key as-number)
@@ -1180,11 +1187,8 @@ After setting the stylevars run hooks according to STYLENAME
   ;; :after-hook (c-update-modeline)
   ;; (setq abbrev-mode t)
 
-  (unless (string= php-mode-cc-vertion c-version)
-    (user-error "CC Mode has been updated.  %s"
-                (if (package-installed-p 'php-mode)
-                    "Please run `M-x package-reinstall php-mode' command."
-                  "Please byte recompile PHP Mode files.")))
+  (unless (string= php-mode-cc-version c-version)
+    (php-mode-debug-reinstall))
 
   (if php-mode-disable-c-mode-hook
       (php-mode-neutralize-cc-mode-effect)


### PR DESCRIPTION
PHP Mode depends on Cc Mode functions and macros, so in general byte-compiled code must be recompiled when Cc Mode version changes. This function prompts the user to reinstall PHP Mode.

Generally, the only people who need to use this command are those who have installed another version of Emacs themselves, or who have compiled their own Emacs HEAD.

If you have installed PHP Mode via a package manager, it would be wiser to update via that mechanism rather than this function.