### PR TITLE
Add Emacs 29.1 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           - "27.2"
           - "28.1"
           - "28.2"
+          - "29.1"
           - release-snapshot
           - snapshot
         include:


### PR DESCRIPTION
> **Note**
>  This released version supports Emacs 29. <br />Please feel free to [write to disucuss][disscussions-emacs29] if you have problems upgrading to Emacs 29.

[disscussions-emacs29]: https://github.com/emacs-php/php-mode/discussions/751