### PR TITLE
Remove Phan-specific features from php-project.el

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes of the PHP Mode 1.19.1 release series are documented in this file using the [Keep a CHANGELOG](https://keepachangelog.com/) principles.
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Removed
+
+ * Removed Phan-specific features from `php-project` ([#754])
+
+[#754]: https://github.com/emacs-php/php-mode/pull/754
 
 ## [1.25.0] - 2023-07-24
 

--- a/lisp/php-project.el
+++ b/lisp/php-project.el
@@ -40,12 +40,6 @@
 ;;
 ;; Return path to PHP executable file with the project settings overriding.
 ;;
-;; ### `php-project-get-phan-executable()'
-;;
-;; Return path to Phan executable file with the project settings overriding.
-;; Phan is a static analyzer and LSP server implementation for PHP.
-;; See https://github.com/phan/phan
-;;
 ;; ## `.dir-locals.el' support
 ;;
 ;; - `php-project-coding-style'
@@ -59,10 +53,6 @@
 ;; - `php-project-php-executable'
 ;;   - Path to project specific PHP executable file.
 ;;   - If you want to use a file different from the system wide `php' command.
-;; - `php-project-phan-executable'
-;;   - Path to project specific Phan executable file.
-;;   - When not specified explicitly, it is automatically searched from
-;;     Composer's dependency of the project and `exec-path'.
 ;;
 
 ;;; Code:
@@ -141,10 +131,6 @@ defines constants, and sets the class loaders.")
     "Path to php executable file.")
   (put 'php-project-php-executable 'safe-local-variable
        #'(lambda (v) (and (stringp v) (file-executable-p v))))
-
-  (defvar-local php-project-phan-executable nil
-    "Path to phan executable file.")
-  (put 'php-project-phan-executable 'safe-local-variable #'php-project--eval-bootstrap-scripts)
 
   (defvar-local php-project-coding-style nil
     "Symbol value of the coding style of the project that PHP major mode refers to.
@@ -239,13 +225,6 @@ Typically it is `pear', `drupal', `wordpress', `symfony2' and `psr2'.")
     php-project-php-executable)
    ((boundp 'php-executable) php-executable)
    (t (executable-find "php"))))
-
-(defun php-project-get-phan-executable ()
-  "Return path to phan executable file."
-  (or (car-safe (php-project--eval-bootstrap-scripts
-                 (list php-project-phan-executable
-                       (cons 'root "vendor/bin/phan"))))
-      (executable-find "phan")))
 
 (defun php-project-get-file-html-template-type (filename)
   "Return symbol T, NIL or `auto' by `FILENAME'."


### PR DESCRIPTION
This variable and function were merged in #436.

[Phan](https://github.com/phan/phan) was the only working PHP static analyzer back in 2018, but Phan is probably not called via this variable today.

Don't worry, PHPDoc will still support highlighting `@phan-` prefixed tags.