### PR TITLE
php-magical-constant: align implementation with php-ts-mode

### DIFF
--- a/lisp/php.el
+++ b/lisp/php.el
@@ -206,7 +206,8 @@ a completion list."
 
 ;;; PHP Keywords
 (defconst php-magical-constants
-  (list "__LINE__" "__FILE__" "__FUNCTION__" "__CLASS__" "__TRAIT__" "__METHOD__" "__NAMESPACE__")
+  '("__CLASS__" "__DIR__" "__FILE__" "__FUNCTION__" "__LINE__"
+    "__METHOD__" "__NAMESPACE__" "__TRAIT__")
   "Magical keyword that is expanded at compile time.
 
 These are different from \"constants\" in strict terms.


### PR DESCRIPTION
Uses quote and adds missing `__DIR__`