### PR TITLE
fix byte compilation warnings

### DIFF
--- a/lisp/php-face.el
+++ b/lisp/php-face.el
@@ -126,7 +126,8 @@
   :tag "PHP Object Op")
 
 (defface php-paamayim-nekudotayim '((t ()))
-  "PHP Mode face used to highlight \"Paamayim Nekudotayim\" scope resolution operators (::)."
+  "PHP Mode face used to highlight scope resolution operators (::).
+The operator is also knows as \"Paamayim Nekudotayim\"."
   :group 'php-faces
   :tag "PHP Paamayim Nekudotayim")
 
@@ -209,7 +210,8 @@
   :tag "PHP Class Declaration")
 
 (defface php-class-declaration-spec '((t (:inherit php-keyword)))
-  "PHP Mode Face used to highlight class declaration specification keywords (implements, extends)."
+  "PHP Mode Face used to highlight class declaration specification keywords.
+The keywords include: implements, extends."
   :group 'php-faces
   :tag "PHP Class Declaration Specification")
 
@@ -239,7 +241,8 @@
   :tag "PHP Visibility Modifier")
 
 (defface php-control-structure '((t (:inherit php-keyword)))
-  "PHP Mode Face used to highlight control structures (if, foreach, while, switch, catch...)."
+ "PHP Mode Face used to highlight control structures.
+The control structures include: if, foreach, while, switch, catch."
   :group 'php-faces
   :tag "PHP Control Structure")
 

--- a/lisp/php-format.el
+++ b/lisp/php-format.el
@@ -98,10 +98,10 @@
   "A formatter symbol, or a list of command and arguments."
   :tag "PHP Format Command"
   :type '(choice (const :tag "Disabled reformat codes" nil)
-                 (const :tag "Auto" 'auto)
-                 (const :tag "Easy Coding Standard" 'ecs)
-                 (const :tag "PHP-CS-Fixer" 'php-cs-fixer)
-                 (const :tag "PHP Code Beautifier and Fixer" 'phpcbf)
+                 (const :tag "Auto" auto)
+                 (const :tag "Easy Coding Standard" ecs)
+                 (const :tag "PHP-CS-Fixer" php-cs-fixer)
+                 (const :tag "PHP Code Beautifier and Fixer" phpcbf)
                  (repeat :tag "Command and arguments" string))
   :safe (lambda (v) (or (symbolp v) (listp v)))
   :group 'php-format)


### PR DESCRIPTION
Fixes:
```
lisp/php-face.el:128:2: Warning: custom-declare-face `php-paamayim-nekudotayim' docstring wider than 80 characters
lisp/php-face.el:211:2: Warning: custom-declare-face `php-class-declaration-spec' docstring wider than 80 characters
lisp/php-face.el:241:2: Warning: custom-declare-face `php-control-structure' docstring wider than 80 characters
```
and
```
lisp/php-format.el:97:12: Warning: defcustom for ‘php-format-command’ has syntactically odd type ‘'(choice (const :tag Disabled reformat codes nil) (const :tag Auto 'auto) (const :tag Easy Coding Standard 'ecs) (const :tag PHP-CS-Fixer 'php-cs-fixer) (const :tag PHP Code Beautifier and Fixer 'phpcbf) (repeat :tag Command and arguments string))’
```