### PR TITLE
Add (require 'flymake-proc)

### DIFF
--- a/lisp/php-flymake.el
+++ b/lisp/php-flymake.el
@@ -26,6 +26,7 @@
 
 ;;; Code:
 (require 'flymake)
+(require 'flymake-proc)
 (require 'cl-lib)
 (eval-when-compile
   (require 'pcase)

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -83,6 +83,7 @@
   (require 'rx)
   (require 'cl-lib)
   (require 'flymake)
+  (require 'flymake-proc)
   (require 'php-flymake)
   (require 'regexp-opt)
   (declare-function acm-backend-tabnine-candidate-expand "ext:acm-backend-tabnine"


### PR DESCRIPTION
The following changes have been commited to the Emacs master branch.
https://github.com/emacs-mirror/emacs/commit/81c6569e654966c63f208013a4faf7ddb2a5d933

The places where `flymake-proc` is used within php-mode are as follows.

```console
$ git grep "flymake-proc" .
lisp/php-flymake.el:  (setq-local flymake-proc-allowed-file-name-masks nil)
lisp/php-mode.el:   (unless (boundp 'flymake-proc-allowed-file-name-masks)

$
```

https://github.com/emacs-php/php-mode/commit/7e93315a8e28a26f5f8398ecd519beff00ca9a82 I added (require 'flymake-proc) in this commit.