### PR TITLE
Add php-topsy-beginning-of-defun-with-class for Topsy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
 
 ## Unreleased
 
+### Added
+
+ * Add `php-topsy-beginning-of-defun-with-class` to display classname with function signature. ([#766])
+
 ### Removed
 
  * Removed Phan-specific features from `php-project` ([#754])
 
 [#754]: https://github.com/emacs-php/php-mode/pull/754
+[#766]: https://github.com/emacs-php/php-mode/pull/766
 
 ## [1.25.0] - 2023-07-24
 


### PR DESCRIPTION
[topsy.el](https://github.com/alphapapa/topsy.el) works without any configuration, but this configuration allows you to view classes as well as just functions.

## Before

<img width="407" alt="スクリーンショット 2023-11-17 21 24 36" src="https://github.com/emacs-php/php-mode/assets/822086/ef996a12-b70e-439d-a6a4-64e943751258">

## After

<img width="558" alt="スクリーンショット 2023-11-17 21 23 44" src="https://github.com/emacs-php/php-mode/assets/822086/35071630-7ebe-4661-8383-12c39ad36151">
