### PR TITLE
Make php-mode inherit from php-base-mode instead of c-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
  * Add `php-base-mode` which is the base of php related modes ([#772])
    * `php-base-mode` is designed as a common parent mode for `php-mode` and [`php-ts-mode`](https://github.com/emacs-php/php-ts-mode).
 
+### Changed
+
+ * Make `php-mode` inherit from `php-base-mode` instead of `c-mode` ([#772])
+
 [#772]: https://github.com/emacs-php/php-mode/pull/772
 
 ## [1.25.1] - 2023-11-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 All notable changes of the PHP Mode 1.19.1 release series are documented in this file using the [Keep a CHANGELOG](https://keepachangelog.com/) principles.
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+ * Add `php-base-mode` which is the base of php related modes ([#772])
+   * `php-base-mode` is designed as a common parent mode for `php-mode` and [`php-ts-mode`](https://github.com/emacs-php/php-ts-mode).
+
+[#772]: https://github.com/emacs-php/php-mode/pull/772
 
 ## [1.25.1] - 2023-11-24
 

--- a/lisp/php.el
+++ b/lisp/php.el
@@ -628,6 +628,15 @@ Look at the `php-executable' variable instead of the constant \"php\" command."
     (or mode php-default-major-mode)))
 
 ;;;###autoload
+(define-derived-mode php-base-mode prog-mode "PHP"
+  "Generic major mode for editing PHP.
+
+This mode is intended to be inherited by concrete major modes.
+Currently there are `php-mode' and `php-ts-mode'."
+  :group 'php
+  nil)
+
+;;;###autoload
 (defun php-mode-maybe ()
   "Select PHP mode or other major mode."
   (interactive)


### PR DESCRIPTION
Add `php-base-mode` like `js-base-mode` for enhanced interoperability with [`php-ts-mode`](https://github.com/emacs-php/php-ts-mode).

You can use `php-base-mode-hook` for common configuration of `php-mode` and `php-ts-mode`.

closes https://github.com/emacs-php/php-mode/pull/678