### PR TITLE
Remove php-mode-disable-c-mode-hook custom variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,13 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
 
  * Make `php-mode` inherit from `php-base-mode` instead of `c-mode` ([#772])
 
+### Removed
+
+ * Remove `php-mode-disable-c-mode-hook` custom variable and `php-mode-neutralize-cc-mode-effect` function ([#775])
+   * `php-mode` no longer inherits `c-mode`, so this variable won't work.
+
 [#772]: https://github.com/emacs-php/php-mode/pull/772
+[#775]: https://github.com/emacs-php/php-mode/pull/775
 
 ## [1.25.1] - 2023-11-24
 

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -292,13 +292,6 @@ In that case set to `NIL'."
   :tag "PHP Mode Enable Backup Style Variables"
   :type 'boolean)
 
-(define-obsolete-variable-alias 'php-mode-disable-parent-mode-hooks 'php-mode-disable-c-mode-hook "1.21.0")
-(defcustom php-mode-disable-c-mode-hook t
-  "When set to `T', do not run hooks of parent modes (`java-mode', `c-mode')."
-  :tag "PHP Mode Disable C Mode Hook"
-  :type 'boolean)
-(make-obsolete-variable 'php-mode-disable-c-mode-hook nil "1.24.2")
-
 (defcustom php-mode-enable-project-local-variable t
   "When set to `T', apply project local variable to buffer local variable."
   :tag "PHP Mode Enable Project Local Variable"
@@ -1132,13 +1125,6 @@ After setting the stylevars run hook `php-mode-STYLENAME-hook'."
   (php-project-apply-local-variables)
   (remove-hook 'hack-local-variables-hook #'php-mode-set-local-variable-delay))
 
-(defun php-mode-neutralize-cc-mode-effect ()
-  "Reset PHP-irrelevant variables set by Cc Mode initialization."
-  (setq-local c-mode-hook nil)
-  (setq-local java-mode-hook nil)
-  (remove-hook 'flymake-diagnostic-functions 'flymake-cc t)
-  t)
-
 (defvar php-mode-syntax-table
   (let ((table (make-syntax-table)))
     (c-populate-syntax-table table)
@@ -1161,12 +1147,6 @@ After setting the stylevars run hook `php-mode-STYLENAME-hook'."
                      (c-update-modeline))
   (unless (string= php-mode-cc-version c-version)
     (php-mode-debug-reinstall nil))
-
-  (if php-mode-disable-c-mode-hook
-      (php-mode-neutralize-cc-mode-effect)
-    (display-warning 'php-mode
-                     "`php-mode-disable-c-mode-hook' will be removed.  Do not depends on this variable."
-                     :warning))
 
   (c-initialize-cc-mode t)
   (setq abbrev-mode t)


### PR DESCRIPTION
refs #772, `php-mode` no longer inherits `c-mode`, so this variable won't work.