### PR TITLE
Modify over-indentation for PEAR style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,23 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
 ### Changed
 
  * Make `php-mode` inherit from `php-base-mode` instead of `c-mode` ([#772])
+ * Modify indentation of [PEAR Coding Standards] ([#774], [#777])
+   * No longer overindent it by default, since we don't see any mention in the coding style that it should hang `.`. (refs [#227] and [#229])
+   * **If you have any feedback on PEAR style, please let us know in [the discussion #776][#776].**
 
 ### Removed
 
  * Remove `php-mode-disable-c-mode-hook` custom variable and `php-mode-neutralize-cc-mode-effect` function ([#775])
    * `php-mode` no longer inherits `c-mode`, so this variable won't work.
 
+[#227]: https://github.com/emacs-php/php-mode/pull/227
+[#229]: https://github.com/emacs-php/php-mode/pull/229
 [#772]: https://github.com/emacs-php/php-mode/pull/772
+[#774]: https://github.com/emacs-php/php-mode/issues/774
 [#775]: https://github.com/emacs-php/php-mode/pull/775
+[#776]: https://github.com/emacs-php/php-mode/discussions/776
+[#777]: https://github.com/emacs-php/php-mode/pull/777
+[PEAR Coding Standards]: https://pear.php.net/manual/en/standards.php
 
 ## [1.25.1] - 2023-11-24
 

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -709,7 +709,7 @@ a backward search limit."
  "pear"
  '("php"
    (c-basic-offset . 4)
-   (c-offsets-alist . ((case-label . 0)))
+   (c-offsets-alist . ((case-label . 0) (statement-cont . +)))
    (tab-width . 4)
    (php-mode-lineup-cascaded-calls . nil)))
 

--- a/tests/indent/issue-227.php
+++ b/tests/indent/issue-227.php
@@ -8,5 +8,5 @@
 
 function my_func() {
     return "a really long string with = inside " .
-"some more text";   // ###php-mode-test### ((indent 49))
+"some more text";   // ###php-mode-test### ((indent 8))
 }

--- a/tests/indent/issue-774.php
+++ b/tests/indent/issue-774.php
@@ -1,0 +1,11 @@
+<?php
+
+$someObject->someFunction("some", "parameter") // ###php-mode-test### ((indent 0))
+    ->someOtherFunc(23, 42) // ###php-mode-test### ((indent 4))
+    ->andAThirdFunction(); // ###php-mode-test### ((indent 4))
+
+$result = DateTime::createFromFormat('Y-m-d', '2112-09-03') // ###php-mode-test### ((indent 0))
+    ->someFunction(); // ###php-mode-test### ((indent 4))
+
+$pages = $dbOld->createQueryBuilder() // ###php-mode-test### ((indent 0))
+    ->select('*'); // ###php-mode-test### ((indent 4))

--- a/tests/php-mode-test.el
+++ b/tests/php-mode-test.el
@@ -522,11 +522,6 @@ style from Drupal."
     (search-forward "return")
     (should (eq (current-indentation) (* 2 c-basic-offset)))))
 
-(ert-deftest php-mode-test-issue-227 ()
-  "multi-line strings indents "
-  (custom-set-variables '(php-lineup-cascaded-calls t))
-  (with-php-mode-test ("issue-227.php" :indent t :style pear :magic t)))
-
 (ert-deftest php-mode-test-issue-237 ()
   "Indent chaining method for PSR2."
   (with-php-mode-test ("issue-237.php" :indent t :style psr2 :magic t)))
@@ -695,6 +690,11 @@ Meant for `php-mode-test-issue-503'."
   (with-php-mode-test ("lang/types/keywords.php" :faces t))
   (with-php-mode-test ("lang/errorcontrol.php" :faces t))
   (with-php-mode-test ("lang/magical-constants/echo.php" :faces t)))
+
+(ert-deftest php-mode-test-pear ()
+  "Tests for PEAR style."
+  (with-php-mode-test ("indent/issue-227.php" :indent t :magic t :style pear))
+  (with-php-mode-test ("indent/issue-774.php" :indent t :magic t :style pear)))
 
 ;; For developers: How to make .faces list file.
 ;;


### PR DESCRIPTION
No longer overindent it by default, since we don't see any mention in the coding style that it should hang `.`. 

closes #227, #774 and #745, refs #229.

> [!NOTE]
> If you have any feedback on [PEAR style](https://pear.php.net/manual/en/standards.php), please let us know in [the discussion #776](https://github.com/emacs-php/php-mode/discussions/776).