### PR TITLE
On Emacs >= 29.1, `php-function-call` face inherits from `font-lock-function-call-face`

### DIFF
--- a/lisp/php-face.el
+++ b/lisp/php-face.el
@@ -55,7 +55,11 @@
   :group 'php-faces
   :tag "PHP Function Name")
 
-(defface php-function-call '((t ()))
+;; `font-lock-function-call-face' was added in Emacs 29.1
+(defface php-function-call (eval-when-compile
+                             (if (get 'font-lock-function-call-face 'face-defface-spec)
+                                 '((t (:inherit font-lock-function-call-face)))
+                               '((t ()))))
   "PHP Mode face used to highlight function names in calles."
   :group 'php-faces
   :tag "PHP Function Call")

--- a/tests/php-mode-test.el
+++ b/tests/php-mode-test.el
@@ -653,6 +653,12 @@ Meant for `php-mode-test-issue-503'."
   (with-php-mode-test ("indent/issue-702.php" :indent t :magic t))
   (with-php-mode-test ("indent/issue-726.php" :indent t :magic t)))
 
+(ert-deftest php-mode-test-issue-782 ()
+  "Test that function calls are fontified."
+  (if (version< emacs-version "29.1")
+      (should (eq (face-attribute 'php-function-call :inherit) nil))
+    (should (eq (face-attribute 'php-function-call :inherit) 'font-lock-function-call-face))))
+
 (ert-deftest php-mode-test-php74 ()
   "Test highlighting language constructs added in PHP 7.4."
   (with-php-mode-test ("7.4/arrow-function.php" :faces t))


### PR DESCRIPTION
Resolves #782