### PR TITLE
Just call syntax-ppss-flush-cache instead of an explicit property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
    * `php-method-call` → `php-method-call-traditional`
    * `php-static-method-call` → `php-static-method-call-traditional`
  * Add variables for the `php-function-call`, `php-method-call`, and `php-static-method-call` faces, defaulting to the `-traditional` face.
+ * Changes how php-syntax-propertize-rules are applied for the first time. ([#785] and [#786])
+   * This change is expected to make heredoc and attribute coloring more stable and reduce flicker.
 
 ### Removed
 
@@ -39,6 +41,8 @@ All notable changes of the PHP Mode 1.19.1 release series are documented in this
 [#777]: https://github.com/emacs-php/php-mode/pull/777
 [#780]: https://github.com/emacs-php/php-mode/issues/780
 [#782]: https://github.com/emacs-php/php-mode/issues/782
+[#785]: https://github.com/emacs-php/php-mode/issues/785
+[#786]: https://github.com/emacs-php/php-mode/pull/786
 [@bricka]: https://github.com/bricka
 [emacs-php/php-ts-mode#68]: https://github.com/emacs-php/php-ts-mode/pull/68
 [PEAR Coding Standards]: https://pear.php.net/manual/en/standards.php

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -1,6 +1,6 @@
 ;;; php-mode.el --- Major mode for editing PHP code  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2023  Friends of Emacs-PHP development
+;; Copyright (C) 2024  Friends of Emacs-PHP development
 ;; Copyright (C) 1999, 2000, 2001, 2003, 2004 Turadg Aleahmad
 ;;               2008 Aaron S. Hawley
 ;;               2011, 2012, 2013, 2014, 2015, 2016, 2017 Eric James Michael Ritz
@@ -1242,12 +1242,7 @@ After setting the stylevars run hook `php-mode-STYLENAME-hook'."
               :filter-args #'php-acm-backend-tabnine-candidate-expand-filter-args)
 
   (when (eval-when-compile (>= emacs-major-version 25))
-    (with-silent-modifications
-      (save-excursion
-        (let* ((start (point-min))
-               (end (min (point-max)
-                         (+ start syntax-propertize-chunk-size))))
-          (php-syntax-propertize-function start end))))))
+    (syntax-ppss-flush-cache (point-min))))
 
 (declare-function semantic-create-imenu-index "semantic/imenu" (&optional stream))
 


### PR DESCRIPTION
resolve https://github.com/emacs-php/php-mode/issues/785

This issue was first introduced in #316 as a workaround for a problem with Emacs 25 not coloring properly. This approach was disadvantageous for large files, and although performance was improved in #531, we often suffered from flickering.

The previous approach of reapplying `php-syntax-propertize-function` was messing with Emacs' internal state, so resetting it seems to fix a lot of the issues.

refs https://github.com/emacs-php/php-mode/issues/491, https://github.com/emacs-php/php-mode/pull/308