### PR TITLE
Drop support for Emacs 26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version:
-          - "26.3"
           - "27.2"
           - "28.2"
           - "29.4"
@@ -36,8 +35,6 @@ jobs:
             emacs-version: snapshot
             experimental: true
         exclude:
-          - os: macos-latest
-            emacs-version: "26.3"
           - os: macos-latest
             emacs-version: "27.2"
     steps:

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -10,7 +10,7 @@
 ;; URL: https://github.com/emacs-php/php-mode
 ;; Keywords: languages php
 ;; Version: 1.26.1
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "27.1"))
 ;; License: GPL-3.0-or-later
 
 (eval-and-compile


### PR DESCRIPTION
> [!NOTE]
> The last PHP Mode that supports Emacs 26 is [`v1.26`](https://github.com/emacs-php/php-mode/releases/tag/v1.26.1).
> Please read #464 and #771 for our support policy.