### PR TITLE
Fix array alignment issue when an empty line is present

### DIFF
--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -627,8 +627,7 @@ but only if the setting is enabled."
    ((assq 'defun-block-intro c-syntactic-context) nil)
    ((assq 'defun-close c-syntactic-context) nil)
    ((assq 'statement-cont c-syntactic-context) nil)
-   (t
-    (save-excursion
+   ((save-excursion
       (beginning-of-line)
       (let ((beginning-of-langelem (cdr langelem))
             (beginning-of-current-line (point))
@@ -651,8 +650,10 @@ but only if the setting is enabled."
               (skip-chars-backward " 	\r\n")
               (backward-char 1))
             (and (not (eq (point) beginning-of-current-line))
+                 (not (php-in-string-or-comment-p))
                  (not (looking-at-p ","))
-                 (not (php-in-string-or-comment-p))))
+                 (save-excursion
+                   (backward-char) (not (looking-at-p ",")))))
           '+)
          (t nil)))))))
 

--- a/tests/indent/issue-793.php
+++ b/tests/indent/issue-793.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'foo' => 1, // ###php-mode-test### ((indent 4))
+    'bar' => 2,
+
+'buz' => 3, // ###php-mode-test### ((indent 4))
+'buzbuz' => 4, // ###php-mode-test### ((indent 4))
+];

--- a/tests/php-mode-test.el
+++ b/tests/php-mode-test.el
@@ -644,14 +644,14 @@ Meant for `php-mode-test-issue-503'."
     (goto-char (point-min))
     (should (eq (php-mode-test-in-function-p nil) nil))))
 
-(ert-deftest php-mode-test-issue-623 ()
-  "Proper alignment object -> accessor."
-  (with-php-mode-test ("indent/issue-623.php" :indent t :magic t)))
-
-(ert-deftest php-mode-test-issue-702 ()
-  "Proper alignment arglist."
+(ert-deftest php-mode-test-indentation-issues ()
+  ;; Proper alignment object -> accessor.
+  (with-php-mode-test ("indent/issue-623.php" :indent t :magic t))
+  ;; Proper alignment arglist.
   (with-php-mode-test ("indent/issue-702.php" :indent t :magic t))
-  (with-php-mode-test ("indent/issue-726.php" :indent t :magic t)))
+  (with-php-mode-test ("indent/issue-726.php" :indent t :magic t))
+  ;; Proper alignment arglist that contains empty lines.
+  (with-php-mode-test ("indent/issue-793.php" :indent t :magic t)))
 
 (ert-deftest php-mode-test-php74 ()
   "Test highlighting language constructs added in PHP 7.4."


### PR DESCRIPTION
Fixed https://github.com/emacs-php/php-mode/issues/793