### PR TITLE
Support Emacs HEAD(32)

### DIFF
--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -1516,7 +1516,7 @@ for \\[find-tag] (which see)."
    ;;   already fontified by another pattern. Note that using OVERRIDE
    ;;   is usually overkill.
    `(
-     ("\\<\\(@\\)" 1 'php-errorcontrol-op)
+     (php-mode--error-control-op-font-lock-find 0 'php-errorcontrol-op t)
      ;; import function statement
      (,(rx symbol-start (group "use" (+ (syntax whitespace)) "function")
            (+ (syntax whitespace)))
@@ -1617,6 +1617,24 @@ The output will appear in the buffer *PHP*."
 
 (defconst php-string-interpolated-variable-regexp
   "{\\$[^}\n\\\\]*\\(?:\\\\.[^}\n\\\\]*\\)*}\\|\\${\\sw+}\\|\\$\\sw+")
+
+(defun php-mode--error-control-op-font-lock-find (limit)
+  "Font-lock matcher for the error-control operator `@' up to LIMIT.
+
+Match a single `@' that is used as the error-control operator, skipping
+occurrences inside strings or comments and the `@new' keyword (which CC
+Mode fontifies as a keyword).  CC Mode >= 31 fontifies a bare `@' as a
+keyword because `@new' is registered in `c-type-list-kwds', so this
+matcher is set to override that face."
+  (let (found)
+    (while (and (not found)
+                (re-search-forward "@" limit t))
+      (unless (or (php-in-string-or-comment-p)
+                  (save-excursion
+                    (goto-char (match-beginning 0))
+                    (looking-at-p "@new\\_>")))
+        (setq found t)))
+    found))
 
 (defun php-mode--string-interpolated-variable-font-lock-find (limit)
   "Apply text-property to LIMIT for string interpolation by font-lock."

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -470,6 +470,12 @@ any) is a brace list.
 PHP does not have an C-like \"enum\" keyword."
   php nil)
 
+;; cc-mode renamed `c-after-brace-list-decl-kwds' to `c-after-enum-list-kwds';
+;; keep the old name defined so cc-langs' transitional lookup stays quiet where
+;; the rename landed (see `c-after-enum-list-key' in cc-langs.el).
+(c-lang-defconst c-after-brace-list-decl-kwds
+  php nil)
+
 (c-lang-defconst c-typeless-decl-kwds
   php (append (c-lang-const c-class-decl-kwds php) '("function" "const")))
 

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -102,7 +102,7 @@
             (let ((tag (replace-regexp-in-string
                         (rx bos "v") ""
                         (shell-command-to-string "git describe --tags")))
-                  (pattern (rx (group (+ any)) eol)))
+                  (pattern (rx (group (+ nonl)) eol)))
               (if (string-match pattern tag)
                   (match-string 0 tag)
                 (error "Faild to obtain git tag"))))

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -1185,13 +1185,19 @@ After setting the stylevars run hook `php-mode-STYLENAME-hook'."
   (setq-local comment-end "")
   (setq-local page-delimiter php-mode-page-delimiter)
 
-  (setq-local font-lock-string-face 'php-string)
-  (setq-local font-lock-keyword-face 'php-keyword)
-  (setq-local font-lock-builtin-face 'php-builtin)
-  (setq-local c-preprocessor-face-name 'php-php-tag)
-  (setq-local font-lock-function-name-face 'php-function-name)
-  (setq-local font-lock-variable-name-face 'php-variable-name)
-  (setq-local font-lock-constant-face 'php-constant)
+  (with-suppressed-warnings ((obsolete font-lock-string-face
+                                       font-lock-keyword-face
+                                       font-lock-builtin-face
+                                       font-lock-function-name-face
+                                       font-lock-variable-name-face
+                                       font-lock-constant-face))
+    (setq-local font-lock-string-face 'php-string)
+    (setq-local font-lock-keyword-face 'php-keyword)
+    (setq-local font-lock-builtin-face 'php-builtin)
+    (setq-local c-preprocessor-face-name 'php-php-tag)
+    (setq-local font-lock-function-name-face 'php-function-name)
+    (setq-local font-lock-variable-name-face 'php-variable-name)
+    (setq-local font-lock-constant-face 'php-constant))
 
   (setq-local syntax-propertize-function #'php-syntax-propertize-function)
   (add-hook 'syntax-propertize-extend-region-functions

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -1629,7 +1629,10 @@ matcher is set to override that face."
   (let (found)
     (while (and (not found)
                 (re-search-forward "@" limit t))
-      (unless (or (php-in-string-or-comment-p)
+      ;; `php-in-string-or-comment-p' calls `syntax-ppss', which may run
+      ;; `syntax-propertize' and clobber the match data, so guard it to
+      ;; keep the `@' match for both the `@new' check below and font-lock.
+      (unless (or (save-match-data (php-in-string-or-comment-p))
                   (save-excursion
                     (goto-char (match-beginning 0))
                     (looking-at-p "@new\\_>")))

--- a/lisp/php-mode.el
+++ b/lisp/php-mode.el
@@ -681,6 +681,57 @@ a backward search limit."
         (cons (point) t))))
    (t nil)))
 
+(defun php-mode--anonymous-function-brace-p (pos)
+  "Return non-nil when the opening brace at POS starts a closure body.
+
+POS must be the position of a `{'.  A closure is an anonymous
+`function (...) [use (...)] [: type] {' expression; named function
+declarations and other constructs (e.g. `match', `if') return nil."
+  (save-excursion
+    (goto-char pos)
+    (c-backward-syntactic-ws)
+    ;; Step back over an optional return type declaration `): Type {' so
+    ;; that point lands just after the parameter (or `use') list's `)'.
+    (unless (eq (char-before) ?\))
+      (let ((colon (save-excursion
+                     (skip-chars-backward "^):;{}(" (point-min))
+                     (and (eq (char-before) ?:) (1- (point))))))
+        (when colon
+          (goto-char colon)
+          (c-backward-syntactic-ws))))
+    ;; Walk backwards over the `)...(' list(s): the parameter list, plus an
+    ;; optional `use (...)' clause, until we reach `function' or give up.
+    (let ((result nil) (continue t))
+      (while (and continue (eq (char-before) ?\)))
+        (condition-case nil
+            (backward-list)
+          (error (setq continue nil)))
+        (when continue
+          (c-backward-syntactic-ws)
+          (if (zerop (c-backward-token-2))
+              (cond
+               ((looking-at-p "\\_<function\\_>") (setq result t continue nil))
+               ((looking-at-p "\\_<use\\_>") (c-backward-syntactic-ws))
+               (t (setq continue nil)))
+            (setq continue nil))))
+      result)))
+
+(defun php-c-looking-at-statement-block (orig-fun &rest args)
+  "Treat a closure body as a statement block around `c-looking-at-statement-block'.
+
+Emacs' CC Mode >= 31 (the change for bug#19867) fails to recognize an
+anonymous function body whose first line is a comment as a statement
+block, and reports it as a brace list, mis-indenting both the body and
+its closing brace.  When point is at the opening brace of such a closure,
+return non-nil; otherwise fall back to ORIG-FUN with ARGS.
+
+A closure body is always a statement block, so this is also correct on
+Emacs versions unaffected by the bug."
+  (or (and (derived-mode-p 'php-mode)
+           (eq (char-after) ?\{)
+           (php-mode--anonymous-function-brace-p (point)))
+      (apply orig-fun args)))
+
 (c-add-style
  "php"
  `((c-basic-offset . 4)
@@ -1256,6 +1307,9 @@ After setting the stylevars run hook `php-mode-STYLENAME-hook'."
 
   (advice-add 'c-looking-at-or-maybe-in-bracelist
               :around 'php-c-looking-at-or-maybe-in-bracelist)
+  (when (fboundp 'c-looking-at-statement-block)
+    (advice-add 'c-looking-at-statement-block
+                :around 'php-c-looking-at-statement-block))
   (advice-add 'fixup-whitespace :after #'php-mode--fixup-whitespace-after)
 
   (advice-add 'acm-backend-tabnine-candidate-expand

--- a/lisp/php.el
+++ b/lisp/php.el
@@ -327,7 +327,7 @@ which will be the name of the method."
                        (* (syntax whitespace))
                        "("
                        ,@(when include-args
-                           '((* any) line-end))))))
+                           '((* nonl) line-end))))))
 
   (defun php-create-regexp-for-classlike (type)
     "Accepts a `TYPE' of a `classlike' object as a string, such as
@@ -378,7 +378,7 @@ can be used to match against definitions for that classlike."
              (+ (or (syntax word) (syntax symbol)))
              (* (syntax whitespace))
              (? "=" (* (syntax whitespace))
-                (repeat 0 40 any))))
+                (repeat 0 40 nonl))))
        1)
       ("Functions"
        ,(rx line-start
@@ -389,7 +389,7 @@ can be used to match against definitions for that classlike."
              (+ (or (syntax word) (syntax symbol)))
              (* (syntax whitespace))
              "("
-             (repeat 0 100 any)))
+             (repeat 0 100 nonl)))
        1)
       ("Import"
        ,(rx line-start
@@ -397,7 +397,7 @@ can be used to match against definitions for that classlike."
             (group
              "use"
              (+ (syntax whitespace))
-             (repeat 0 100 any)))
+             (repeat 0 100 nonl)))
        1)
       ("Classes"
        ,(php-create-regexp-for-classlike "\\(?:class\\|interface\\|trait\\|enum\\)") 0)


### PR DESCRIPTION
This PR makes php-mode work on Emacs HEAD (the future Emacs 32) while keeping Emacs 27 through 30 working.

CI is green on Emacs 27.2, 28.2, 29.4, 30.2, and snapshot across Linux, macOS, and Windows.

## CC Mode regressions in Emacs 31 and later

Two defects come from CC Mode changes that landed between Emacs 30.2 and 31.0.90.
Both are masked on older Emacs and only appear from 31 onward.

### Closure body indentation

The change for bug#19867 made `c-looking-at-statement-block` stop treating a brace block as a statement block when its content is inconclusive, for example a closure body whose first line is only a comment.
CC Mode then falls back to context analysis.
For an anonymous `function () { ... }` the token before the parameter list is the `function` keyword rather than a function name, so the body is classified as a brace list.
That mis-indents both the body and its closing brace.
The `lang/function/closure.php` indentation test fails on Emacs 31 and 32 but passes on 30.2.

Fix: advise `c-looking-at-statement-block` to report a closure opening brace as a statement block.
A closure body always is one, so the advice is also correct on Emacs versions that are not affected.

### Error control operator `@`

CC Mode 31 fontifies a bare `@` as a keyword, because `@new` is registered in `c-type-list-kwds`.
The error control operator in `@fopen(...)` or `@$a` was highlighted as `php-keyword` instead of `php-errorcontrol-op`.
The old matcher `\<\(@\)` never matched anything, because `@` has punctuation syntax and a word boundary can never precede it.
The `lang/errorcontrol.php` faces test fails on Emacs 31 and 32.

Fix: replace the matcher with a function that highlights a single `@` as the error control operator with override, while skipping `@` inside strings and comments and the `@new` keyword.
The match data is guarded with `save-match-data`, because `php-in-string-or-comment-p` calls `syntax-ppss`, which can run `syntax-propertize` and clobber the match set for font-lock.

## Other Emacs HEAD compatibility fixes

### c-after-brace-list-decl-kwds

CC Mode renamed `c-after-brace-list-decl-kwds` to `c-after-enum-list-kwds`.
Keep the old name defined so the transitional lookup in cc-langs stays quiet.

### rx forms

Replace bare `any` with `nonl` in several rx patterns.
Both match any character except newline, and `nonl` states the intent directly.

### Obsolete font-lock variables

Several `font-lock-*-face` variables are now obsolete.
Wrap the assignments in `with-suppressed-warnings` to silence byte-compile warnings without changing behavior.
