### PR TITLE
Remove redundant :group keywords from defcustom/defface forms

### DIFF
--- a/lisp/php-complete.el
+++ b/lisp/php-complete.el
@@ -51,8 +51,7 @@
   :type (eval-when-compile `(set ,@(mapcar (lambda (elm) (list 'const (car elm)))
                                            php-defs-functions-alist)))
   :safe (lambda (value) (and (listp value) (cl-loop for v in values
-                                                    always (assq v php-defs-functions-alist))))
-  :group 'php-complete)
+                                                    always (assq v php-defs-functions-alist)))))
 
 ;;; Cape functions:
 

--- a/lisp/php-face.el
+++ b/lisp/php-face.el
@@ -37,155 +37,126 @@
 
 (defface php-string '((t (:inherit font-lock-string-face)))
   "PHP Mode face used to highlight string literals."
-  :group 'php-faces
   :tag "PHP String")
 
 (defface php-keyword '((t (:inherit font-lock-keyword-face)))
   "PHP Mode face used to highlight keywords."
-  :group 'php-faces
   :tag "PHP Keyword")
 
 (defface php-builtin '((t (:inherit font-lock-builtin-face)))
   "PHP Mode face used to highlight builtins."
-  :group 'php-faces
   :tag "PHP Built-in")
 
 (defface php-function-name '((t (:inherit font-lock-function-name-face)))
   "PHP Mode face used to highlight function names."
-  :group 'php-faces
   :tag "PHP Function Name")
 
 (defface php-function-call-standard `((t ,(when (eval-when-compile (get 'font-lock-function-call-face 'face-defface-spec))
                                             '(:inherit font-lock-function-call-face))))
   "PHP Mode face used to highlight function names in calles."
-  :group 'php-faces
   :tag "PHP Function Call Standard")
 
 (defface php-function-call-traditional '((t ()))
   "PHP Mode face used to highlight function names in calles."
-  :group 'php-faces
   :tag "PHP Function Call Traditional")
 
 (define-obsolete-face-alias 'php-function-call 'php-function-call-traditional "1.26.0")
 
 (defface php-method-call-standard '((t (:inherit php-function-call-standard)))
   "PHP Mode face used to highlight method names in calles."
-  :group 'php-faces
   :tag "PHP Method Call Standard")
 
 (defface php-method-call-traditional '((t (:inherit php-function-call-traditional)))
   "PHP Mode face used to highlight method names in calles."
-  :group 'php-faces
   :tag "PHP Method Call Traditional")
 
 (define-obsolete-face-alias 'php-method-call 'php-method-call-traditional "1.26.0")
 
 (defface php-static-method-call-standard '((t (:inherit php-method-call-standard)))
   "PHP Mode face used to highlight static method names in calles."
-  :group 'php-faces
   :tag "PHP Static Method Call Standard")
 
 (defface php-static-method-call-traditional '((t (:inherit php-method-call-traditional)))
   "PHP Mode face used to highlight static method names in calles."
-  :group 'php-faces
   :tag "PHP Static Method Call Traditional")
 
 (define-obsolete-face-alias 'php-static-method-call 'php-static-method-call-traditional "1.26.0")
 
 (defface php-variable-name '((t (:inherit font-lock-variable-name-face)))
   "PHP Mode face used to highlight variable names."
-  :group 'php-faces
   :tag "PHP Variable Name")
 
 (defface php-property-name '((t (:inherit php-variable-name)))
   "PHP Mode face used to highlight property names."
-  :group 'php-faces
   :tag "PHP Property Name")
 
 (defface php-variable-sigil '((t ()))
   "PHP Mode face used to highlight variable sigils ($)."
-  :group 'php-faces
   :tag "PHP Variable Sigil")
 
 (defface php-operator '((t ()))
   "PHP Mode face used to operators."
-  :group 'php-faces
   :tag "PHP Operator")
 
 (defface php-assignment-op '((t (:inherit php-operator)))
   "PHP Mode face used to assignment operators (=, +=, ...)."
-  :group 'php-faces
   :tag "PHP Object Op")
 
 (defface php-comparison-op '((t (:inherit php-operator)))
   "PHP Mode face used to comparison operators (==, !=, ===, ...)."
-  :group 'php-faces
   :tag "PHP Comparison Op")
 
 (defface php-logical-op '((t (:inherit php-operator)))
   "PHP Mode face used to logical operators (&&, ||, ?:)."
-  :group 'php-faces
   :tag "PHP Logical Op")
 
 (defface php-arithmetic-op '((t (:inherit php-operator)))
   "PHP Mode face used to arithmetic operators (+, -, %, ...)."
-  :group 'php-faces
   :tag "PHP Arithmetic Op")
 
 (defface php-inc-dec-op '((t (:inherit php-operator)))
   "PHP Mode face used to increment and decremt operators (--, ++)."
-  :group 'php-faces
   :tag "PHP Increment/Decrement Op")
 
 (defface php-string-op '((t (:inherit php-operator)))
   "PHP Mode face used to logical operators (.)."
-  :group 'php-faces
   :tag "PHP String Op")
 
 (defface php-object-op '((t (:inherit php-operator)))
   "PHP Mode face used to object operators (->)."
-  :group 'php-faces
   :tag "PHP Object Op")
 
 (defface php-paamayim-nekudotayim '((t ()))
   "PHP Mode face used to highlight scope resolution operators (::).
 The operator is also knows as \"Paamayim Nekudotayim\"."
-  :group 'php-faces
   :tag "PHP Paamayim Nekudotayim")
 
 (defface php-type '((t (:inherit font-lock-type-face)))
   "PHP Mode face used to highlight types."
-  :group 'php-faces
   :tag "PHP Type")
 
 (defface php-class '((t (:inherit font-lock-type-face)))
   "PHP Mode face used to highlight class."
-  :group 'php-faces
   :tag "PHP Class")
 
 (defface php-constant '((t (:inherit font-lock-constant-face)))
   "PHP Mode face used to highlight constants."
-  :group 'php-faces
   :tag "PHP Constant")
 
 (defface php-constant-assign '((t (:inherit php-constant)))
   "PHP Mode face used to highlight constant assigning (\"const\" statement)."
-  :group 'php-faces
   :tag "PHP Constant Assign")
 
 (defface php-magical-constant '((t (:inherit font-lock-builtin-face)))
   "PHP Mode face used to highlight magical constants."
-  :group 'php-faces
   :tag "PHP Magical Constant")
 
 (defface php-this '((t (:inherit php-constant)))
   "PHP Mode face used to highlight $this variables."
-  :group 'php-faces
   :tag "PHP $this")
 
 (defface php-this-sigil '((t (:inherit php-constant)))
   "PHP Mode face used to highlight sigils($) of $this variable."
-  :group 'php-faces
   :tag "PHP $this Sigil")
 
 (define-obsolete-face-alias 'php-$this 'php-this "1.26.0")
@@ -193,12 +164,10 @@ The operator is also knows as \"Paamayim Nekudotayim\"."
 
 (defface php-errorcontrol-op '((t (:inherit font-lock-type-face)))
   "PHP Mode face used to highlight errorcontrol operators (@).."
-  :group 'php-faces
   :tag "PHP ErrorControl Op")
 
 (defface php-php-tag '((t (:inherit font-lock-preprocessor-face)))
   "PHP Mode face used to highlight PHP tags."
-  :group 'php-faces
   :tag "PHP php Tag")
 
 (defface php-doc-annotation-tag (eval-when-compile
@@ -206,69 +175,56 @@ The operator is also knows as \"Paamayim Nekudotayim\"."
                                       '((t . (:inherit font-lock-doc-markup-face)))
                                     '((t . (:inherit font-lock-constant-face)))))
   "Face used to highlight annotation tags in doc-comment."
-  :group 'php-faces
   :tag "PHPDoc Annotation Tag")
 
 (defface php-doc-variable-sigil '((t (:inherit font-lock-variable-name-face)))
   "PHP Mode face used to highlight variable sigils($)."
-  :group 'php-faces
   :tag "PHPDoc Variable Sigil")
 
 (defface php-doc-$this '((t (:inherit php-type)))
   "PHP Mode face used to highlight $this variable in doc-comment."
-  :group 'php-faces
   :tag "PHPDoc $this")
 
 (defface php-doc-$this-sigil '((t (:inherit php-type)))
   "PHP Mode face used to highlight sigil of $this variable in doc-comment."
-  :group 'php-faces
   :tag "PHPDoc $this Sigil")
 
 (defface php-doc-class-name '((t (:inherit php-string)))
   "PHP Mode Face used to class names in doc-comment."
-  :group 'php-faces
   :tag "PHPDoc Class Name")
 
 (defface php-class-declaration '((t (:inherit php-keyword)))
   "PHP Mode Face used to class declarations."
-  :group 'php-faces
   :tag "PHP Class Declaration")
 
 (defface php-class-declaration-spec '((t (:inherit php-keyword)))
   "PHP Mode Face used to highlight class declaration specification keywords.
 The keywords include: implements, extends."
-  :group 'php-faces
   :tag "PHP Class Declaration Specification")
 
 (defface php-namespace-declaration '((t (:inherit php-keyword)))
   "PHP Mode Face used to highlight namespace declaration keyword."
-  :group 'php-faces
   :tag "PHP Namespace Declaration")
 
 (defface php-import-declaration '((t (:inherit php-keyword)))
   "PHP Mode Face used to highlight import statements (use ... as ...)."
-  :group 'php-faces
   :tag "PHP Import Statement")
 
 (defface php-class-modifier '((t (:inherit php-keyword)))
   "PHP Mode Face used to highlight class modifiers (final, abstract)."
-  :group 'php-faces
   :tag "PHP Class Modifier")
 
 (defface php-method-modifier '((t (:inherit php-keyword)))
   "PHP Mode Face used to highlight method modifiers (final, abstract)."
-  :group 'php-faces
   :tag "PHP Method Modifier")
 
 (defface php-visibility-modifier '((t (:inherit php-keyword)))
   "PHP Mode Face used to highlight access keywords (public, protected, private)."
-  :group 'php-faces
   :tag "PHP Visibility Modifier")
 
 (defface php-control-structure '((t (:inherit php-keyword)))
  "PHP Mode Face used to highlight control structures.
 The control structures include: if, foreach, while, switch, catch."
-  :group 'php-faces
   :tag "PHP Control Structure")
 
 (define-obsolete-face-alias 'php-annotations-annotation-face 'php-doc-annotation-tag "1.19.0")

--- a/lisp/php-flymake.el
+++ b/lisp/php-flymake.el
@@ -40,7 +40,6 @@
 
 (defcustom php-flymake-executable-command-args nil
   "List of command and arguments for `php -l'."
-  :group 'php-flymake
   :type '(repeat string)
   :safe (lambda (v) (and (listp v) (cl-every v #'stringp))))
 

--- a/lisp/php-format.el
+++ b/lisp/php-format.el
@@ -103,15 +103,13 @@
                  (const :tag "PHP-CS-Fixer" php-cs-fixer)
                  (const :tag "PHP Code Beautifier and Fixer" phpcbf)
                  (repeat :tag "Command and arguments" string))
-  :safe (lambda (v) (or (symbolp v) (listp v)))
-  :group 'php-format)
+  :safe (lambda (v) (or (symbolp v) (listp v))))
 
 (defcustom php-format-command-dir "vendor/bin"
   "A relative path to the directory where formatting tool is installed."
   :tag "PHP Format Command"
   :type 'string
-  :safe #'stringp
-  :group 'php-format)
+  :safe #'stringp)
 
 (defcustom php-format-default-idle-time 3
   "Number of seconds to wait idle before formatting."
@@ -126,14 +124,12 @@
   "An alist of misplay the result method of the formatting process."
   :tag "PHP Format Result Display Method"
   :type '(alist :key-type function
-                :value-type symbol)
-  :group 'php-format)
+                :value-type symbol))
 
 (defcustom php-format-disable-async-format-buffer-has-modified t
   "When set to non-NIL, disables async formatting if buffer is modified (unsaved)."
   :tag "PHP Format Disable Async Format Buffer Has Modified"
-  :type 'boolean
-  :group 'php-format)
+  :type 'boolean)
 
 ;; Internal functions
 (defsubst php-format--register-timer (sec command-args)
@@ -226,7 +222,6 @@
 ;;;###autoload
 (define-minor-mode php-format-auto-mode
   "Automatically apply formatting when saving an edited file."
-  :group 'php-format
   :lighter php-format-lighter
   (if php-format-auto-mode
       (add-hook 'after-save-hook 'php-format-on-after-save-hook php-format-auto-mode-hook-depth t)

--- a/lisp/php-ide-phpactor.el
+++ b/lisp/php-ide-phpactor.el
@@ -58,8 +58,7 @@
               (const hover)
               (const navigation))
   :safe (lambda (xs) (and (listp xs)
-                          (cl-every (lambda (x) (memq x '(all hover navigation))) xs)))
-  :group 'php-ide-phpactor)
+                          (cl-every (lambda (x) (memq x '(all hover navigation))) xs))))
 
 (defvar php-ide-phpactor-timer nil
   "Timer object for execute Phpactor and display hover message.")

--- a/lisp/php-ide.el
+++ b/lisp/php-ide.el
@@ -139,7 +139,6 @@
 (defcustom php-ide-features nil
   "A set of PHP-IDE features symbol."
   :tag "PHP-IDE Feature"
-  :group 'php-ide
   :type `(set ,@(mapcar (lambda (feature) (list 'const (car feature)))
                        php-ide-feature-alist)
               symbol)
@@ -150,7 +149,6 @@
 (defcustom php-ide-eglot-executable nil
   "Command name or path to the command of Eglot LSP executable."
   :tag "PHP-IDE Eglot Executable"
-  :group 'php-ide
   :type '(choice
           (const intelephense)
           (const phpactor)
@@ -174,7 +172,6 @@
 (defcustom php-ide-mode-lighter " PHP-IDE"
   "A symbol of PHP-IDE feature."
   :tag "PHP-IDE Mode Lighter"
-  :group 'php-ide
   :type 'string
   :safe #'stringp)
 
@@ -186,7 +183,6 @@ Notice that two arguments (FEATURE ACTIVATE) are given.
 FEATURE: A symbol, like \\='lsp-mode.
 ACTIVATE: T is given when activeting, NIL when deactivating PHP-IDE."
   :tag "PHP-IDE Mode Functions"
-  :group 'php-ide
   :type '(repeat function)
   :safe (lambda (functions)
           (and (listp functions) (cl-every #'functionp functions))))

--- a/lisp/php-project.el
+++ b/lisp/php-project.el
@@ -73,13 +73,11 @@
 (defcustom php-project-auto-detect-etags-file nil
   "If `T', automatically detect etags file when file is opened."
   :tag "PHP Project Auto Detect Etags File"
-  :group 'php-project
   :type 'boolean)
 
 (defcustom php-project-use-projectile-to-detect-root nil
   "If `T' and projectile-mode is activated, use Projectile for root detection."
   :tag "PHP Project Use Projectile To Detect Root"
-  :group 'php-project
   :type 'boolean)
 
 ;; Variables

--- a/lisp/php.el
+++ b/lisp/php.el
@@ -51,19 +51,16 @@
 
 (defcustom php-executable (or (executable-find "php") "php")
   "The location of the PHP executable."
-  :group 'php
   :tag "PHP Executable"
   :type 'string)
 
 (defcustom php-phpdbg-executable (list "phpdbg")
   "The location of the PHPDBG executable."
-  :group 'php
   :tag "PHP PHPDBG Executable"
   :type '(repeat string))
 
 (defcustom php-php-parse-executabe nil
   "The location of the php-parse executable."
-  :group 'php
   :tag "PHP php-parse Executable"
   :type '(repeat string))
 
@@ -71,14 +68,12 @@
   "Default PHP.net site URL.
 
 The URL to use open PHP manual and search word."
-  :group 'php
   :tag "PHP Site URL"
   :type 'string)
 
 (defcustom php-manual-url 'en
   "URL at which to find PHP manual.
 You can replace \"en\" with your ISO language code."
-  :group 'php
   :tag "PHP Manual URL"
   :type '(choice (const  :tag "English" en)
                  (const  :tag "Brazilian Portuguese" pt_BR)
@@ -94,7 +89,6 @@ You can replace \"en\" with your ISO language code."
 
 (defcustom php-search-url nil
   "URL at which to search for documentation on a word."
-  :group 'php
   :tag "PHP Search URL"
   :type '(choice (string :tag "URL to search PHP documentation")
                  (const  :tag "Use `php-site-url' variable" nil)))
@@ -109,7 +103,6 @@ You can replace \"en\" with your ISO language code."
 
 (defcustom php-search-documentation-function #'php-search-web-documentation
   "Function to search PHP Manual at cursor position."
-  :group 'php
   :tag "PHP Search Documentation Function"
   :type '(choice (const :tag "Use online documentation" php-search-web-documentation)
                  (const :tag "Use local documentation" php-local-manual-search)
@@ -120,7 +113,6 @@ You can replace \"en\" with your ISO language code."
 
 If non-nil, this shadows the value of `browse-url-browser-function' when
 calling `php-search-documentation' or `php-search-local-documentation'."
-  :group 'php
   :tag "PHP Search Documentation Browser Function"
   :type '(choice (const :tag "default" nil) function)
   :link '(variable-link browse-url-browser-function))
@@ -165,29 +157,24 @@ a completion list."
 
 (defcustom php-class-suffix-when-insert "::"
   "Suffix for inserted class."
-  :group 'php
   :type 'string)
 
 (defcustom php-namespace-suffix-when-insert "\\"
   "Suffix for inserted namespace."
-  :group 'php
   :type 'string)
 
 (defcustom php-default-major-mode 'php-mode
   "Major mode for editing PHP script."
-  :group 'php
   :tag "PHP Default Major Mode"
   :type 'function)
 
 (defcustom php-html-template-major-mode 'web-mode
   "Major mode for editing PHP-HTML template."
-  :group 'php
   :tag "PHP-HTML Template Major Mode"
   :type 'function)
 
 (defcustom php-blade-template-major-mode 'web-mode
   "Major mode for editing Blade template."
-  :group 'php
   :tag "PHP Blade Template Major Mode"
   :type 'function)
 
@@ -196,7 +183,6 @@ a completion list."
     ("\\.phpt\\'" . ,(if (fboundp 'phpt-mode) 'phpt-mode php-default-major-mode))
     ("\\.phtml\\'" . ,php-html-template-major-mode))
   "Automatically use another MAJOR-MODE when open template file."
-  :group 'php
   :tag "PHP Template Mode Alist"
   :type '(alist :key-type regexp :value-type function)
   :link '(url-link :tag "web-mode" "http://web-mode.org/")
@@ -204,13 +190,11 @@ a completion list."
 
 (defcustom php-mode-maybe-hook nil
   "List of functions to be executed on entry to `php-mode-maybe'."
-  :group 'php
   :tag "PHP Mode Maybe Hook"
   :type 'hook)
 
 (defcustom php-default-builtin-web-server-port 3939
   "Port number of PHP Built-in HTTP server (php -S)."
-  :group 'php
   :tag "PHP Default Built-in Web Server Port"
   :type 'integer
   :link '(url-link :tag "Built-in web server"
@@ -218,25 +202,21 @@ a completion list."
 
 (defcustom php-topsy-separator " > "
   "Separator string for `php-topsy-beginning-of-defun-with-class'."
-  :group 'php
   :tag "PHP Topsy Separator"
   :type 'string)
 
 (defcustom php-function-call 'php-function-call-traditional
   "Face name to use for method call."
-  :group 'php
   :tag "PHP Function Call"
   :type 'face)
 
 (defcustom php-method-call 'php-method-call-traditional
   "Face name to use for method call."
-  :group 'php
   :tag "PHP Method Call"
   :type 'face)
 
 (defcustom php-static-method-call 'php-static-method-call-traditional
   "Face name to use for method call."
-  :group 'php
   :tag "PHP Static Method Call"
   :type 'face)
 
@@ -474,8 +454,7 @@ can be used to match against definitions for that classlike."
   :type '(choice (alist :key-type string :value-type (list string))
                  (const php-imenu-generic-expression-legacy)
                  (const php-imenu-generic-expression-simple)
-                 variable)
-  :group 'php)
+                 variable))
 
 (defconst php--re-namespace-pattern
   (eval-when-compile
@@ -620,7 +599,6 @@ Look at the `php-executable' variable instead of the constant \"php\" command."
 
 (defcustom php-re-detect-html-tag 'php-re-detect-html-tag-default
   "Regexp pattern variable-name of HTML detection."
-  :group 'php
   :tag "PHP Re Detect HTML Tag"
   :type '(choice (const :tag "Default pattern" php-re-detect-html-tag-default)
                  (const :tag "Aggressive pattern" php-re-detect-html-tag-aggressive)
@@ -681,7 +659,6 @@ indentation."
 
 This mode is intended to be inherited by concrete major modes.
 Currently there are `php-mode' and `php-ts-mode'."
-  :group 'php
   nil)
 
 ;;;###autoload


### PR DESCRIPTION
## Summary

A `defcustom`/`defface` form without an explicit `:group` belongs to the group of the last `defgroup` defined earlier in the same file, so repeating that group on every single form is redundant boilerplate. This drops the self-group `:group` keyword in the files that define their own group:

* `php.el` (group `php`)
* `php-face.el` (group `php-faces`)
* `php-format.el` (group `php-format`)
* `php-ide.el` (group `php-ide`)
* `php-ide-phpactor.el` (group `php-ide-phpactor`)
* `php-flymake.el` (group `php-flymake`)
* `php-complete.el` (group `php-complete`)
* `php-project.el` (group `php-project`)

Kept untouched:

* Parent links on the `defgroup` forms themselves.
* Explicit cross-group memberships (e.g. `:group 'php` on a few `defcustom`s inside `php-format.el` that intentionally file themselves under the parent group instead of `php-format`), whose removal would change the containing group.

## Verification

Loaded every file before and after the change and compared `(get GROUP 'custom-group)` for `php`, `php-mode`, `php-faces`, `php-format`, `php-ide`, `php-ide-phpactor`, `php-flymake`, `php-complete` and `php-project` — membership is byte-for-byte identical. Byte-compilation is clean (no new warnings), and the existing test suite (`tests/php-mode-test.el`) passes unchanged.