### PR TITLE
Add php-core.el for the dependency-free primitives

### DIFF
--- a/Eask
+++ b/Eask
@@ -10,6 +10,7 @@
 (package-file "lisp/php-mode.el")
 (files
  "lisp/php.el"
+ "lisp/php-core.el"
  "lisp/php-complete.el"
  "lisp/php-defs.el"
  "lisp/php-indent.el"

--- a/lisp/php-core.el
+++ b/lisp/php-core.el
@@ -1,0 +1,93 @@
+;;; php-core.el --- Core definitions shared by PHP packages  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026  Friends of Emacs-PHP development
+
+;; Author: USAMI Kenta <tadsan@zonu.me>
+;; Maintainer: USAMI Kenta <tadsan@zonu.me>
+;; URL: https://github.com/emacs-php/php-mode
+;; Keywords: languages, php
+;; License: GPL-3.0-or-later
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file holds the handful of definitions that every PHP package
+;; needs and that depend on nothing else: the `php' customization group,
+;; the `php-executable' path, the `syntax-ppss' predicates and the
+;; `php-base-mode' parent mode.
+;;
+;; It exists so that a module can reach those primitives without pulling
+;; in the whole of php.el, which requires `flymake' and `php-project'
+;; (and, for now, CC Mode).  php.el itself requires this file and
+;; re-exports everything here, so `(require 'php)' keeps working exactly
+;; as before; nothing needs to migrate.
+;;
+;; Keep this file free of dependencies.  Anything that needs `flymake',
+;; `php-project', CC Mode or a PHP syntax table belongs in php.el, not
+;; here.
+
+;;; Code:
+
+
+;;; Customization group
+
+;;;###autoload
+(defgroup php nil
+  "Language support for PHP."
+  :tag "PHP"
+  :group 'languages
+  :link '(url-link :tag "Official Site" "https://github.com/emacs-php/php-mode")
+  :link '(url-link :tag "PHP Mode Wiki" "https://github.com/emacs-php/php-mode/wiki"))
+
+(defcustom php-executable (or (executable-find "php") "php")
+  "The location of the PHP executable."
+  :tag "PHP Executable"
+  :type 'string)
+
+
+;;; Utility for locating language constructs
+
+(defsubst php-in-string-p ()
+  "Return non-nil if inside a string.
+It is the character that will terminate the string, or t if the string should
+be terminated by a generic string delimiter."
+  (nth 3 (syntax-ppss)))
+
+(defsubst php-in-comment-p ()
+  "Return NIL if outside a comment, T if inside a non-nestable comment, else
+an integer (the current comment nesting)."
+  (nth 4 (syntax-ppss)))
+
+(defsubst php-in-string-or-comment-p ()
+  "Return character address of start of comment or string; nil if not in one."
+  (nth 8 (syntax-ppss)))
+
+(defsubst php-in-poly-php-html-mode ()
+  "Return T if current buffer is in `poly-html-mode'."
+  (bound-and-true-p poly-php-html-mode))
+
+
+;;; Base major mode
+
+;;;###autoload
+(define-derived-mode php-base-mode prog-mode "PHP"
+  "Generic major mode for editing PHP.
+
+This mode is intended to be inherited by concrete major modes.
+Currently there are `php-mode' and `php-ts-mode'."
+  nil)
+
+(provide 'php-core)
+;;; php-core.el ends here

--- a/lisp/php-indent.el
+++ b/lisp/php-indent.el
@@ -40,7 +40,7 @@
 
 ;;; Code:
 
-(require 'php)
+(require 'php-core)
 
 ;;; Customization
 

--- a/lisp/php.el
+++ b/lisp/php.el
@@ -38,29 +38,19 @@
   (require 'cl-lib))
 (require 'cc-engine)
 (require 'flymake)
+(require 'php-core)
 (require 'php-project)
 (require 'rx)
 
-;;;###autoload
-(defgroup php nil
-  "Language support for PHP."
-  :tag "PHP"
-  :group 'languages
-  :link '(url-link :tag "Official Site" "https://github.com/emacs-php/php-mode")
-  :link '(url-link :tag "PHP Mode Wiki" "https://github.com/emacs-php/php-mode/wiki"))
-
-(defcustom php-executable (or (executable-find "php") "php")
-  "The location of the PHP executable."
-  :tag "PHP Executable"
-  :type 'string)
-
 (defcustom php-phpdbg-executable (list "phpdbg")
   "The location of the PHPDBG executable."
+  :group 'php
   :tag "PHP PHPDBG Executable"
   :type '(repeat string))
 
 (defcustom php-php-parse-executabe nil
   "The location of the php-parse executable."
+  :group 'php
   :tag "PHP php-parse Executable"
   :type '(repeat string))
 
@@ -68,12 +58,14 @@
   "Default PHP.net site URL.
 
 The URL to use open PHP manual and search word."
+  :group 'php
   :tag "PHP Site URL"
   :type 'string)
 
 (defcustom php-manual-url 'en
   "URL at which to find PHP manual.
 You can replace \"en\" with your ISO language code."
+  :group 'php
   :tag "PHP Manual URL"
   :type '(choice (const  :tag "English" en)
                  (const  :tag "Brazilian Portuguese" pt_BR)
@@ -89,20 +81,24 @@ You can replace \"en\" with your ISO language code."
 
 (defcustom php-search-url nil
   "URL at which to search for documentation on a word."
+  :group 'php
   :tag "PHP Search URL"
   :type '(choice (string :tag "URL to search PHP documentation")
                  (const  :tag "Use `php-site-url' variable" nil)))
 
 (defcustom php-completion-file ""
   "Path to the file which contains the function names known to PHP."
+  :group 'php
   :type 'string)
 
 (defcustom php-manual-path ""
   "Path to the directory which contains the PHP manual."
+  :group 'php
   :type 'string)
 
 (defcustom php-search-documentation-function #'php-search-web-documentation
   "Function to search PHP Manual at cursor position."
+  :group 'php
   :tag "PHP Search Documentation Function"
   :type '(choice (const :tag "Use online documentation" php-search-web-documentation)
                  (const :tag "Use local documentation" php-local-manual-search)
@@ -113,6 +109,7 @@ You can replace \"en\" with your ISO language code."
 
 If non-nil, this shadows the value of `browse-url-browser-function' when
 calling `php-search-documentation' or `php-search-local-documentation'."
+  :group 'php
   :tag "PHP Search Documentation Browser Function"
   :type '(choice (const :tag "default" nil) function)
   :link '(variable-link browse-url-browser-function))
@@ -157,24 +154,29 @@ a completion list."
 
 (defcustom php-class-suffix-when-insert "::"
   "Suffix for inserted class."
+  :group 'php
   :type 'string)
 
 (defcustom php-namespace-suffix-when-insert "\\"
   "Suffix for inserted namespace."
+  :group 'php
   :type 'string)
 
 (defcustom php-default-major-mode 'php-mode
   "Major mode for editing PHP script."
+  :group 'php
   :tag "PHP Default Major Mode"
   :type 'function)
 
 (defcustom php-html-template-major-mode 'web-mode
   "Major mode for editing PHP-HTML template."
+  :group 'php
   :tag "PHP-HTML Template Major Mode"
   :type 'function)
 
 (defcustom php-blade-template-major-mode 'web-mode
   "Major mode for editing Blade template."
+  :group 'php
   :tag "PHP Blade Template Major Mode"
   :type 'function)
 
@@ -183,6 +185,7 @@ a completion list."
     ("\\.phpt\\'" . ,(if (fboundp 'phpt-mode) 'phpt-mode php-default-major-mode))
     ("\\.phtml\\'" . ,php-html-template-major-mode))
   "Automatically use another MAJOR-MODE when open template file."
+  :group 'php
   :tag "PHP Template Mode Alist"
   :type '(alist :key-type regexp :value-type function)
   :link '(url-link :tag "web-mode" "http://web-mode.org/")
@@ -190,11 +193,13 @@ a completion list."
 
 (defcustom php-mode-maybe-hook nil
   "List of functions to be executed on entry to `php-mode-maybe'."
+  :group 'php
   :tag "PHP Mode Maybe Hook"
   :type 'hook)
 
 (defcustom php-default-builtin-web-server-port 3939
   "Port number of PHP Built-in HTTP server (php -S)."
+  :group 'php
   :tag "PHP Default Built-in Web Server Port"
   :type 'integer
   :link '(url-link :tag "Built-in web server"
@@ -202,21 +207,25 @@ a completion list."
 
 (defcustom php-topsy-separator " > "
   "Separator string for `php-topsy-beginning-of-defun-with-class'."
+  :group 'php
   :tag "PHP Topsy Separator"
   :type 'string)
 
 (defcustom php-function-call 'php-function-call-traditional
   "Face name to use for method call."
+  :group 'php
   :tag "PHP Function Call"
   :type 'face)
 
 (defcustom php-method-call 'php-method-call-traditional
   "Face name to use for method call."
+  :group 'php
   :tag "PHP Method Call"
   :type 'face)
 
 (defcustom php-static-method-call 'php-static-method-call-traditional
   "Face name to use for method call."
+  :group 'php
   :tag "PHP Static Method Call"
   :type 'face)
 
@@ -239,26 +248,6 @@ see https://www.php.net/manual/language.constants.predefined.php")
                       "[" "]" "(" ")" "{" "}" ";")
                 t)))
 
-;;; Utillity for locate language construction
-(defsubst php-in-string-p ()
-  "Return non-nil if inside a string.
-It is the character that will terminate the string, or t if the string should
-be terminated by a generic string delimiter."
-  (nth 3 (syntax-ppss)))
-
-(defsubst php-in-comment-p ()
-  "Return NIL if outside a comment, T if inside a non-nestable comment, else
-an integer (the current comment nesting)."
-  (nth 4 (syntax-ppss)))
-
-(defsubst php-in-string-or-comment-p ()
-  "Return character address of start of comment or string; nil if not in one."
-  (nth 8 (syntax-ppss)))
-
-(defsubst php-in-poly-php-html-mode ()
-  "Return T if current buffer is in `poly-html-mode'."
-  (bound-and-true-p poly-php-html-mode))
-
 (defconst php-beginning-of-defun-regexp
   (eval-when-compile
     (rx bol
@@ -451,6 +440,7 @@ can be used to match against definitions for that classlike."
 
 (defcustom php-imenu-generic-expression 'php-imenu-generic-expression-default
   "Default Imenu generic expression for PHP Mode.  See `imenu-generic-expression'."
+  :group 'php
   :type '(choice (alist :key-type string :value-type (list string))
                  (const php-imenu-generic-expression-legacy)
                  (const php-imenu-generic-expression-simple)
@@ -599,6 +589,7 @@ Look at the `php-executable' variable instead of the constant \"php\" command."
 
 (defcustom php-re-detect-html-tag 'php-re-detect-html-tag-default
   "Regexp pattern variable-name of HTML detection."
+  :group 'php
   :tag "PHP Re Detect HTML Tag"
   :type '(choice (const :tag "Default pattern" php-re-detect-html-tag-default)
                  (const :tag "Aggressive pattern" php-re-detect-html-tag-aggressive)
@@ -652,14 +643,6 @@ indentation."
                 "Please install `web-mode' package")
         (setq mode nil)))
     (or mode php-default-major-mode)))
-
-;;;###autoload
-(define-derived-mode php-base-mode prog-mode "PHP"
-  "Generic major mode for editing PHP.
-
-This mode is intended to be inherited by concrete major modes.
-Currently there are `php-mode' and `php-ts-mode'."
-  nil)
 
 ;;;###autoload
 (defun php-mode-maybe ()


### PR DESCRIPTION
First step of the php.el decomposition, aimed at the v1.28 series.

## Why

php.el is required by every PHP package, but it requires `flymake`, `php-project` and (for now) CC Mode. A module that only wants the `php` customization group or a `syntax-ppss` predicate pays for all of it — measured on a byte-compiled tree:

| | features | time |
|---|---|---|
| `(require 'php)` | 17 | ~53 ms |

The indentation engine pulling in flymake to get a 7-line `defgroup` is the clearest symptom.

## What moves

`lisp/php-core.el` (new, **zero dependencies**):

* the `php` customization group
* `php-executable`
* `php-in-string-p`, `php-in-comment-p`, `php-in-string-or-comment-p`, `php-in-poly-php-html-mode`
* `php-base-mode`

php.el requires php-core.el and therefore still exposes every one of them, so **`(require 'php)` behaves exactly as before and nothing has to migrate**. This is the facade direction: the dependency arrow points core ← php, with no cycle.

php-indent.el, which only ever wanted the customization group, now requires php-core.el instead:

| | features | time |
|---|---|---|
| `(require 'php-indent)` | 2 | ~1 ms |

with no flymake, php-project or cc-engine in its chain.

## Two consequences worth calling out

**php.el's defcustoms specify `:group 'php` again.** #813 removed those as redundant, which was true only while the defgroup sat in the same file: `custom-current-group` keys off `load-file-name`, so with the defgroup in php-core.el they silently fall out of the group. Without this, `M-x customize-group php` lists **2 members instead of 29**. They are required now, not redundant.

**The syntax tables stay in php.el for the moment.** They are built with `c-populate-syntax-table`, so moving them would drag CC Mode into php-core.el and defeat the purpose. They can follow once php.el stops requiring cc-engine.

## Verification

* `(get GROUP 'custom-group)` membership is **identical to master** for every `php*` group (`php`, `php-mode`, `php-faces`, `php-format`, `php-ide`, `php-ide-phpactor`, `php-flymake`, `php-complete`, `php-project`).
* Byte-compiles with no new warnings; the existing test suite is unaffected (62 tests, unchanged).
* php-core.el uses no Emacs 28+ functions, so it does not front-run #811 — this is intended for the Emacs 27-supporting v1.28 series.

## Follow-ups (not here)

* `php-executable` currently has **two** `bound-and-true-p` / `boundp` workarounds — php-project.el:224 and php-flymake.el:104 — because neither can require php.el (php.el requires php-project, so it would be circular). Both can now require php-core.el instead and drop the workaround. Kept out of this PR to keep it a pure move with no behaviour change.
* Moving the syntax tables and the token scanner, once cc-engine is gone from php.el.
* `php-magical-constants` → php-keywords.el with an obsolete alias.