### PR TITLE
Move php-magical-constants to php-keywords.el

### DIFF
--- a/lisp/php-keywords.el
+++ b/lisp/php-keywords.el
@@ -53,12 +53,13 @@
 ;; of scope, and deliberately not duplicated here:
 ;;
 ;;   - built-in function names -- see lisp/php-defs.el;
-;;   - the magic constants (`__LINE__' and friends), which are written
-;;     upper-case and matched case-sensitively -- php.el owns that list
-;;     as `php-magical-constants', and both major modes build their
-;;     font-lock rule from it directly;
 ;;   - predefined runtime constants such as `PHP_EOL' or `PHP_INT_MAX',
 ;;     which are library symbols rather than language keywords.
+;;
+;; `php-magical-constants' is the one exception to the naming convention
+;; above.  It is a long-standing public symbol that php.el used to own,
+;; and both major modes build their font-lock rule straight from it, so
+;; it keeps its name; php.el requires this file and re-exports it.
 
 ;;; Code:
 
@@ -226,21 +227,29 @@ Match against buffer text with `case-fold-search' bound to non-nil.")
 ;; PHP language constants; stored lower-case here, same convention as
 ;; every other list in this file).
 ;;
-;; The magic constants (`__CLASS__', `__LINE__', ...) are intentionally
-;; NOT mirrored here.  They are not part of php-cc-mode.el's 367-609
-;; c-lang-defconst block either: both major modes fontify them straight
-;; from php.el's `php-magical-constants', which stays the single source
-;; of truth for that list.
+;; The magic constants (`__CLASS__', `__LINE__', ...) are not part of
+;; php-cc-mode.el's 367-609 c-lang-defconst block: both major modes
+;; fontify them straight from `php-magical-constants', which php.el used
+;; to define and which now sits below, next to the rest of the
+;; vocabulary.
 (defconst php-keywords--constants
   '("true" "false" "null")
   "PHP literal keywords `true', `false' and `null' (case-insensitive).
 The upper-case magic constants (`__LINE__' and friends) are matched
-case-sensitively and live in php.el's `php-magical-constants'.")
+case-sensitively; see `php-magical-constants'.")
 
 (defconst php-keywords--constants-re
   (regexp-opt php-keywords--constants 'symbols)
   "`regexp-opt' of `php-keywords--constants', symbol-bounded.
 Match against buffer text with `case-fold-search' bound to non-nil.")
+
+(defconst php-magical-constants
+  '("__CLASS__" "__DIR__" "__FILE__" "__FUNCTION__" "__LINE__"
+    "__METHOD__" "__NAMESPACE__" "__TRAIT__")
+  "Magical keyword that is expanded at compile time.
+
+These are different from \"constants\" in strict terms.
+see https://www.php.net/manual/language.constants.predefined.php")
 
 (provide 'php-keywords)
 ;;; php-keywords.el ends here

--- a/lisp/php.el
+++ b/lisp/php.el
@@ -39,6 +39,7 @@
 (require 'cc-engine)
 (require 'flymake)
 (require 'php-core)
+(require 'php-keywords)
 (require 'php-project)
 (require 'rx)
 
@@ -244,14 +245,6 @@ out and get `php-default-major-mode' instead."
   :type 'face)
 
 ;;; PHP Keywords
-(defconst php-magical-constants
-  '("__CLASS__" "__DIR__" "__FILE__" "__FUNCTION__" "__LINE__"
-    "__METHOD__" "__NAMESPACE__" "__TRAIT__")
-  "Magical keyword that is expanded at compile time.
-
-These are different from \"constants\" in strict terms.
-see https://www.php.net/manual/language.constants.predefined.php")
-
 (defconst php-re-token-symbols
   (eval-when-compile
     (regexp-opt (list "&" "&=" "array(" "(array)" "&&" "||" "(bool)" "(boolean)" "break;" "?>" "%>"


### PR DESCRIPTION
Continues the php.el decomposition. Small and self-contained.

## Why

php-keywords.el calls itself *"a single source of truth for PHP keywords"*, but php.el kept a vocabulary list of its own under a `;;; PHP Keywords` heading — so a reader asking where PHP's keywords live got two answers. This moves the list to the module that owns the vocabulary, which makes that claim true.

## The name does not change

`php-magical-constants` stays `php-magical-constants`. It is a long-standing public symbol and both major modes build their `php-magical-constant` font-lock rule straight from it. Keeping the name is also exactly what #815 did — php-core.el holds `php-executable`, `php-in-string-p` and `php-base-mode` under their own names — so:

* no obsolete alias is needed,
* no caller has to change,
* `(require 'php)` behaves exactly as before, because php.el requires php-keywords.el and therefore still exposes it.

(An earlier sketch had this renamed to `php-keywords-magic-constants` with an alias. Dropped — it bought nothing and would have made the file's naming *more* mixed, since everything else there is `php-keywords--*`.)

## Verification

* The `defconst` is moved **byte-for-byte**; `diff` against master confirms it is identical.
* After `(require 'php)`, `php-magical-constants` still holds the same 8 constants.
* php-keywords.el still requires **nothing**, so the dependency arrow keeps pointing the natural way (vocabulary ← everything else), with no cycle.
* Byte-compiles with no new warnings; full suite green.

## Not moved

`php-re-token-symbols` stays in php.el. Its only consumer is php.el's own token scanner, and it is a bare regexp with no list form, so it does not fit this file's `NAME` / `NAME-re` convention.