### PR TITLE
Ship php-flymake.el and php-align.el in the package

### DIFF
--- a/Eask
+++ b/Eask
@@ -16,11 +16,13 @@
  "lisp/php-indent.el"
  "lisp/php-keywords.el"
  "lisp/php-face.el"
+ "lisp/php-flymake.el"
  "lisp/php-format.el"
  "lisp/php-project.el"
  "lisp/php-local-manual.el"
  "lisp/php-ide-phpactor.el"
  "lisp/php-ide.el"
+ "lisp/php-align.el"
  "lisp/php-mode-debug.el")
 
 (script "test" "echo \"Error: no test specified\" && exit 1")


### PR DESCRIPTION
Neither file is listed in Eask's `files`, so neither ends up in the built package. php-mode.el requires php-flymake at load time, which makes the result unusable:

```console
$ eask package /tmp/dist
$ tar xf /tmp/dist/php-mode-1.26.1.tar && cd php-mode-1.26.1
$ emacs -Q --batch -L . --eval "(require 'php-mode)"
Eager macro-expansion failure: (file-missing "Cannot open load file"
  "No such file or directory" "php-flymake")
```

`eask files` listed 14 items; both of these were absent.

## How it went unnoticed

* php-flymake.el has been missing from the list since it was added in dc67eae, php-align.el since the move into `lisp/` in cc63080.
* CI never caught it because `eask test ert` runs against the source tree, where both files are on the load path either way. Only a package *built* from the `files` list is broken.
* MELPA installs via its own recipe rather than this list, so whether users are affected depends on that recipe — but the list should describe the package correctly regardless, and `eask install`/`eask package` are broken today.

php-align.el is not required by anything — users load it themselves — but it is just as much part of the package, and shipping it is the point of it being here.

## Verification

With both listed, the rebuilt package contains them and loads:

```console
$ emacs -Q --batch -L . --eval "(require 'php-mode)"   # → OK
$ ... (fboundp 'php-flymake)                            # → t
```

`make .eask test` is green (65 tests), `eask compile` reports no errors. The two `rx` `any` warnings php-flymake.el now contributes to `eask compile` are pre-existing in that file.